### PR TITLE
Mineunit tests

### DIFF
--- a/.github/workflows/mineunit.yml
+++ b/.github/workflows/mineunit.yml
@@ -1,0 +1,27 @@
+name: mineunit
+
+on: [push, pull_request]
+
+jobs:
+  mineunit:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - id: mineunit
+      uses: mt-mods/mineunit-actions@master
+      with:
+        badge-label: Test coverage
+
+    - uses: KeisukeYamashita/create-comment@v1
+      if: failure() && github.event_name == 'pull_request'
+      with:
+        check-only-first-line: true
+        comment: |
+          ### Mineunit regression tests failed, test log follows:
+          
+          ```
+          ${{ steps.mineunit.outputs.mineunit-stdout }}
+          ```

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,9 +13,10 @@ read_globals = {
 	"ItemStack",
 
 	-- Mods
+	"digilines",
 	"drawers",
 	"intllib",
-        "mesecon",
+	"mesecon",
 	"pipeworks",
 	"xdecor",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,6 +15,7 @@ read_globals = {
 	-- Mods
 	"drawers",
 	"intllib",
+        "mesecon",
 	"pipeworks",
 	"xdecor",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,6 +15,6 @@ read_globals = {
 	-- Mods
 	"drawers",
 	"intllib",
-        "pipeworks",
+	"pipeworks",
 	"xdecor",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -3,14 +3,20 @@ allow_defined_top = true
 max_line_length = 999
 
 globals = {
-    "technic", "minetest",
+	"minetest",
 }
 
 read_globals = {
-    string = {fields = {"split", "trim"}},
-    table = {fields = {"copy", "getn"}},
+	string = {fields = {"split", "trim"}},
+	table = {fields = {"copy", "getn"}},
 
-    "intllib", "ItemStack", "drawers",
+	-- Minetest
+	"ItemStack",
+
+	-- Mods
+	"drawers",
+	"intllib",
+	"xdecor",
 }
 
 files["init.lua"].ignore = { "name", "stack" }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,11 @@
 unused_args = false
 allow_defined_top = true
 
+-- Exclude regression tests / unit tests
+exclude_files = {
+	"**/spec/**",
+}
+
 globals = {
 	"minetest",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,5 +15,6 @@ read_globals = {
 	-- Mods
 	"drawers",
 	"intllib",
+        "pipeworks",
 	"xdecor",
 }

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,14 +1,13 @@
 unused_args = false
 allow_defined_top = true
-max_line_length = 999
 
 globals = {
 	"minetest",
 }
 
 read_globals = {
-	string = {fields = {"split", "trim"}},
-	table = {fields = {"copy", "getn"}},
+	string = {fields = {"split"}},
+	table = {fields = {"copy"}},
 
 	-- Minetest
 	"ItemStack",
@@ -18,5 +17,3 @@ read_globals = {
 	"intllib",
 	"xdecor",
 }
-
-files["init.lua"].ignore = { "name", "stack" }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,80 @@
 ![](https://github.com/mt-mods/wrench/workflows/luacheck/badge.svg)
 [![License](https://img.shields.io/badge/license-LGPLv2.0%2B-purple.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.0.en.html)
+
+<!--
+[![ContentDB](https://content.minetest.net/packages/mt-mods/wrench/shields/downloads/)](https://content.minetest.net/packages/mt-mods/wrench/)
+-->
+
+# Wrench
+
+<img src="textures/technic_wrench.png"/>
+
+The wrench tool allows you to left-click on nodes with inventories to pick them up.
+
+This mod is a fork from wrench/ in https://github.com/mt-mods/technic
+
+# Supported Mods and Nodes
+
+* https://github.com/minetest/minetest_game
+  - bones:bones
+  - default:chest
+  - default:chest_locked
+  - default:furnace
+  - default:sign_wall_wood
+  - default:sign_wall_steel
+* https://github.com/HybridDog/connected_chests
+* https://github.com/minetest-mods/digtron
+  - digtron:battery_holder
+  - digtron:inventory
+  - digtron:fuelstore
+  - digtron:combined_storage
+* https://github.com/minetest-mods/drawers
+  - drawers:wood
+  - drawers:acacia_wood
+  - drawers:aspen_wood
+  - drawers:junglewood
+  - drawers:pine_wood
+* https://github.com/mt-mods/pipeworks
+  - pipeworks:autocrafter
+  - pipeworks:deployer_*
+  - pipeworks:dispenser_*
+* https://github.com/mt-mods/technic
+* https://github.com/minetest-mods/xdecor
+  - xdecor:cabinet
+  - xdecor:cabinet_half
+  - xdecor:empty_shelf
+  - xdecor:multishelf
+  - xdecor:cauldron_*
+  - xdecor:enchantment_table
+  - xdecor:itemframe
+  - xdecor:mailbox
+
+# Settings
+
+in `minetest.conf`
+```ini
+# enable recipe for wrench (default: true)
+wrench.enable_crafting = true
+```
+
+# Contributors (originally technic modpack)
+
+* kpoppel
+* Nekogloop
+* Nore/Ekdohibs
+* ShadowNinja
+* VanessaE
+* BuckarooBanzay
+* OgelGames
+* int-ua
+* S-S-X
+* H-V-Smacker
+* groxxda
+* SwissalpS
+* And many others...
+
+# License (originally technic modpack)
+
+Unless otherwise stated, all components of this modpack are licensed under the
+LGPL, V2 or later.  See also the individual mod folders for their
+secondary/alternate licenses, if any.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - pipeworks:autocrafter
   - pipeworks:deployer_*
   - pipeworks:dispenser_*
+  - pipeworks:nodebreaker_*
 * https://github.com/mt-mods/technic
 * https://github.com/minetest-mods/xdecor
   - xdecor:cabinet

--- a/README.md
+++ b/README.md
@@ -50,11 +50,10 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - xdecor:itemframe
   - xdecor:mailbox
 
-# Settings
-
-in `minetest.conf`
+# Settings in `minetest.conf`
 ```ini
-# enable recipe for wrench (default: true)
+# Only in combination with technic modpack:
+#  enable recipe for wrench (default: true)
 wrench.enable_crafting = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - pipeworks:deployer_*
   - pipeworks:dispenser_*
   - pipeworks:nodebreaker_*
+  - pipeworks:*filter
 * https://github.com/mt-mods/technic
 * https://github.com/minetest-mods/xdecor
   - xdecor:cabinet

--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - drawers:junglewood
   - drawers:pine_wood
 * https://github.com/minetest-mods/mesecons
-  - mesecons_commandblock:commandblock_*
-  - mesecons_detector:node_detector_*
-  - mesecons_detector:object_detector_*
-  - mesecons_luacontroller:luacontroller*
-  - mesecons_microcontroller:microcontroller*
+  - mesecons_commandblock:commandblock_\*
+  - mesecons_detector:node_detector_\*
+  - mesecons_detector:object_detector_\*
+  - mesecons_luacontroller:luacontroller\*
+  - mesecons_microcontroller:microcontroller\*
 * https://notabug.org/tenplus1/mobs_redo
   - mobs:spawner
 * https://github.com/minetest-mods/more_chests
@@ -57,25 +57,38 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - more_chests:big_fridge
   - more_chests:shared
   - more_chests:secret
-  - more_chests:toolbox_*
+  - more_chests:toolbox_\*
 * https://github.com/mt-mods/pipeworks
   - pipeworks:autocrafter
-  - pipeworks:deployer_*
-  - pipeworks:dispenser_*
-  - pipeworks:nodebreaker_*
-  - pipeworks:*filter
+  - pipeworks:deployer_\*
+  - pipeworks:dispenser_\*
+  - pipeworks:nodebreaker_\*
+  - pipeworks:\*filter
   - pipeworks:lua_tube*
-  - pipeworks:mese_sand_tube_*
-  - pipeworks:mese_tube_*
-  - pipeworks:teleport_tube_*
+  - pipeworks:mese_sand_tube_\*
+  - pipeworks:mese_tube_\*
+  - pipeworks:teleport_tube_\*
 * https://github.com/mt-mods/technic
+  - technic:cnc\*
+  - technic:coal_alloy_furnace\*
+  - technic:\*chest\*
+  - technic:injector
+  - technic:tool_workshop
+  - technic:\*_alloy_furnace\*
+  - technic:\*_battery_box\*
+  - technic:\*_centrifuge\*
+  - technic:\*_compressor\*
+  - technic:\*_electric_furnace\*
+  - technic:\*_extractor\*
+  - technic:\*_freezer\*
+  - technic:\*_grinder\*
 * https://github.com/minetest-mods/xdecor
   - realchess:chessboard
   - xdecor:cabinet
   - xdecor:cabinet_half
   - xdecor:empty_shelf
   - xdecor:multishelf
-  - xdecor:cauldron_*
+  - xdecor:cauldron_\*
   - xdecor:enchantment_table
   - xdecor:itemframe
   - xdecor:mailbox

--- a/README.md
+++ b/README.md
@@ -34,6 +34,14 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - drawers:aspen_wood
   - drawers:junglewood
   - drawers:pine_wood
+* https://github.com/minetest-mods/more_chests
+  - more_chests:cobble
+  - more_chests:dropbox
+  - more_chests:fridge
+  - more_chests:big_fridge
+  - more_chests:shared
+  - more_chests:secret
+  - more_chests:toolbox_*
 * https://github.com/mt-mods/pipeworks
   - pipeworks:autocrafter
   - pipeworks:deployer_*
@@ -52,8 +60,7 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
 
 # Settings in `minetest.conf`
 ```ini
-# Only in combination with technic modpack:
-#  enable recipe for wrench (default: true)
+# Allows the wrench to be crafted if either the 'technic' or 'default' mod is installed.
 wrench.enable_crafting = true
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - default:furnace
   - default:sign_wall_wood
   - default:sign_wall_steel
+  - vessels:shelf
+* https://github.com/minetest-mods/3d_armor
+  - 3d_armor_stand:armor_stand
+  - 3d_armor_stand:locked_armor_stand
+* https://notabug.org/TenPlus1/bees
+  - bees:hive_wild
+* https://github.com/Lokrates/Biofuel
+  - biofuel:refinery
 * https://github.com/HybridDog/connected_chests
 * https://github.com/minetest-mods/digtron
   - digtron:battery_holder
@@ -34,6 +42,14 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - drawers:aspen_wood
   - drawers:junglewood
   - drawers:pine_wood
+* https://github.com/minetest-mods/mesecons
+  - mesecons_commandblock:commandblock_*
+  - mesecons_detector:node_detector_*
+  - mesecons_detector:object_detector_*
+  - mesecons_luacontroller:luacontroller*
+  - mesecons_microcontroller:microcontroller*
+* https://notabug.org/tenplus1/mobs_redo
+  - mobs:spawner
 * https://github.com/minetest-mods/more_chests
   - more_chests:cobble
   - more_chests:dropbox
@@ -48,8 +64,13 @@ This mod is a fork from wrench/ in https://github.com/mt-mods/technic
   - pipeworks:dispenser_*
   - pipeworks:nodebreaker_*
   - pipeworks:*filter
+  - pipeworks:lua_tube*
+  - pipeworks:mese_sand_tube_*
+  - pipeworks:mese_tube_*
+  - pipeworks:teleport_tube_*
 * https://github.com/mt-mods/technic
 * https://github.com/minetest-mods/xdecor
+  - realchess:chessboard
   - xdecor:cabinet
   - xdecor:cabinet_half
   - xdecor:empty_shelf

--- a/api.lua
+++ b/api.lua
@@ -1,0 +1,42 @@
+
+function wrench.register_node(name, def)
+	assert(type(name) == "string", "wrench.register_node invalid type for name")
+	assert(type(def) == "table", "wrench.register_node invalid type for def")
+	local node_def = minetest.registered_nodes[name]
+	if node_def then
+		local old_after_place = node_def.after_place_node
+		minetest.override_item(name, {
+			after_place_node = function(...)
+				if not wrench.restore_node(...) and old_after_place then
+					return old_after_place(...)
+				end
+			end
+		})
+		def = table.copy(def)
+		if def.drop == true and type(node_def.drop) == "string" then
+			def.drop = node_def.drop
+		elseif def.drop and type(def.drop) ~= "string" then
+			minetest.log("warning", "Ignoring invalid type for drop in definition for "..name)
+			def.drop = nil
+		end
+		if def.drop and not wrench.registered_nodes[def.drop] then
+			if def.drop ~= name then
+				minetest.log("warning", "Ignoring unsupported node for drop in definition for "..name)
+			end
+			def.drop = nil
+		end
+		wrench.registered_nodes[name] = def
+	else
+		minetest.log("warning", "Attempt to register unknown node for wrench: "..name)
+	end
+end
+
+function wrench.blacklist_item(name)
+	assert(type(name) == "string", "wrench:blacklist_item invalid type for name")
+	local node_def = minetest.registered_items[name]
+	if node_def then
+		wrench.blacklisted_items[name] = true
+	else
+		minetest.log("warning", "Attempt to blacklist unknown item for wrench: "..name)
+	end
+end

--- a/api.lua
+++ b/api.lua
@@ -1,13 +1,13 @@
 
-function wrench.register_node(name, def)
-	assert(type(name) == "string", "wrench.register_node invalid type for name")
-	assert(type(def) == "table", "wrench.register_node invalid type for def")
+function wrench:register_node(name, def)
+	assert(type(name) == "string", "wrench:register_node invalid type for name")
+	assert(type(def) == "table", "wrench:register_node invalid type for def")
 	local node_def = minetest.registered_nodes[name]
 	if node_def then
 		local old_after_place = node_def.after_place_node
 		minetest.override_item(name, {
 			after_place_node = function(...)
-				if not wrench.restore_node(...) and old_after_place then
+				if not wrench:restore_node(...) and old_after_place then
 					return old_after_place(...)
 				end
 			end
@@ -19,23 +19,23 @@ function wrench.register_node(name, def)
 			minetest.log("warning", "Ignoring invalid type for drop in definition for "..name)
 			def.drop = nil
 		end
-		if def.drop and not wrench.registered_nodes[def.drop] then
+		if def.drop and not self.registered_nodes[def.drop] then
 			if def.drop ~= name then
 				minetest.log("warning", "Ignoring unsupported node for drop in definition for "..name)
 			end
 			def.drop = nil
 		end
-		wrench.registered_nodes[name] = def
+		self.registered_nodes[name] = def
 	else
 		minetest.log("warning", "Attempt to register unknown node for wrench: "..name)
 	end
 end
 
-function wrench.blacklist_item(name)
+function wrench:blacklist_item(name)
 	assert(type(name) == "string", "wrench:blacklist_item invalid type for name")
 	local node_def = minetest.registered_items[name]
 	if node_def then
-		wrench.blacklisted_items[name] = true
+		self.blacklisted_items[name] = true
 	else
 		minetest.log("warning", "Attempt to blacklist unknown item for wrench: "..name)
 	end

--- a/api.lua
+++ b/api.lua
@@ -1,13 +1,13 @@
 
-function wrench:register_node(name, def)
-	assert(type(name) == "string", "wrench:register_node invalid type for name")
-	assert(type(def) == "table", "wrench:register_node invalid type for def")
+function wrench.register_node(name, def)
+	assert(type(name) == "string", "wrench.register_node invalid type for name")
+	assert(type(def) == "table", "wrench.register_node invalid type for def")
 	local node_def = minetest.registered_nodes[name]
 	if node_def then
 		local old_after_place = node_def.after_place_node
 		minetest.override_item(name, {
 			after_place_node = function(...)
-				if not wrench:restore_node(...) and old_after_place then
+				if not wrench.restore_node(...) and old_after_place then
 					return old_after_place(...)
 				end
 			end
@@ -19,24 +19,24 @@ function wrench:register_node(name, def)
 			minetest.log("warning", "Ignoring invalid type for drop in definition for "..name)
 			def.drop = nil
 		end
-		if def.drop and not self.registered_nodes[def.drop] then
+		if def.drop and not wrench.registered_nodes[def.drop] then
 			if def.drop ~= name then
 				minetest.log("warning", "Ignoring unsupported node for drop in definition for "..name)
 			end
 			def.drop = nil
 		end
-		self.registered_nodes[name] = def
+		wrench.registered_nodes[name] = def
 	else
-		minetest.log("warning", "Attempt to register unknown node for wrench: "..name)
+		minetest.log("warning", "Attempt to register unknown node for wrench. "..name)
 	end
 end
 
-function wrench:blacklist_item(name)
-	assert(type(name) == "string", "wrench:blacklist_item invalid type for name")
+function wrench.blacklist_item(name)
+	assert(type(name) == "string", "wrench.blacklist_item invalid type for name")
 	local node_def = minetest.registered_items[name]
 	if node_def then
-		self.blacklisted_items[name] = true
+		wrench.blacklisted_items[name] = true
 	else
-		minetest.log("warning", "Attempt to blacklist unknown item for wrench: "..name)
+		minetest.log("warning", "Attempt to blacklist unknown item for wrench. "..name)
 	end
 end

--- a/debug.lua
+++ b/debug.lua
@@ -8,13 +8,13 @@ local get_keys = function(list)
 end
 
 local orig_wrench_pickup_node = wrench.pickup_node
-wrench.pickup_node = function(self, pos, player)
+wrench.pickup_node = function(pos, player)
 	if not player:get_player_control().sneak then
-		return orig_wrench_pickup_node(self, pos, player)
+		return orig_wrench_pickup_node(pos, player)
 	end
 	local node = minetest.get_node(pos)
 	local def = minetest.registered_nodes[node.name]
-	print("wrench:register_node(\"" .. node.name .. "\", {");
+	print("wrench.register_node(\"" .. node.name .. "\", {");
 	-- timer
 	local timer = minetest.get_node_timer(pos)
 	if timer:get_timeout() ~= 0 then

--- a/debug.lua
+++ b/debug.lua
@@ -7,14 +7,14 @@ local get_keys = function(list)
 	return keys
 end
 
-local orig_wrench_pickup_node = wrench.pickup_node
-wrench.pickup_node = function(pos, player)
+local orig_wrench_pickup_node = wrench:pickup_node
+wrench:pickup_node = function(pos, player)
 	if not player:get_player_control().sneak then
 		return orig_wrench_pickup_node(pos, player)
 	end
 	local node = minetest.get_node(pos)
 	local def = minetest.registered_nodes[node.name]
-	print("wrench.register_node(\"" .. node.name .. "\", {");
+	print("wrench:register_node(\"" .. node.name .. "\", {");
 	-- timer
 	local timer = minetest.get_node_timer(pos)
 	if timer:get_timeout() ~= 0 then
@@ -35,6 +35,13 @@ wrench.pickup_node = function(pos, player)
 	end
 	if def.after_dig_node then
 		print("\t-- has after_dig " .. type(def.after_dig_node))
+	end
+	if def.can_dig then
+		print("\t-- has can_dig " .. type(def.can_dig) .. " " ..
+			((type(def.can_dig) == "function") and
+			(def.can_dig(pos, player) and ', returns rue' or 'returns false') or ""
+			)
+                )
 	end
 	local meta = minetest.get_meta(pos)
 	-- owner

--- a/debug.lua
+++ b/debug.lua
@@ -1,0 +1,75 @@
+
+local get_keys = function(list)
+	local keys = {}
+	for k, _ in pairs(list) do
+		keys[#keys+1] = k
+	end
+	return keys
+end
+
+local orig_wrench_pickup_node = wrench.pickup_node
+wrench.pickup_node = function(pos, player)
+	if not player:get_player_control().sneak then
+		return orig_wrench_pickup_node(pos, player)
+	end
+	local node = minetest.get_node(pos)
+	local def = minetest.registered_nodes[node.name]
+	print("wrench.register_node(\"" .. node.name .. "\", {");
+	-- timer
+	local timer = minetest.get_node_timer(pos)
+	if timer:get_timeout() ~= 0 then
+		print("\ttimer = true,")
+	end
+	-- drop
+	if def.drop then
+		if type(def.drop) ~= "string" then
+			print("\t-- has drop " .. type(def.drop) .. "!")
+		elseif def.drop == node.name or def.drop == node.name .. " 1" then
+			print("\t-- drop = \"" .. def.drop .. "\",")
+		else
+			print("\tdrop = \"" .. def.drop .. "\",")
+		end
+	end
+	if def.after_place_node then
+		print("\t-- has after_place " .. type(def.after_place_node))
+	end
+	if def.after_dig_node then
+		print("\t-- has after_dig " .. type(def.after_dig_node))
+	end
+	local meta = minetest.get_meta(pos)
+	-- owner
+	local owner = meta:get_string("owner")
+	if owner and owner ~= "" then
+		print("\towner = true, -- '" .. owner ..  "' FIXME:?")
+	end
+	-- lists
+	local inventory = meta:get_inventory()
+--	print(dump(inventory))
+	local lists = get_keys(inventory:get_lists())
+	if #lists > 0 then
+		print("\tlists = {\"" .. table.concat(lists, "\", \"") .. "\"},")
+	end
+	-- metas
+	local metatable = meta:to_table()
+	local metas = get_keys(metatable.fields)
+--	print(dump(metatable))
+	if #metas > 0 then
+		print("\tmetas = {")
+		for k, v in pairs(metatable.fields) do
+			local t = "--[[FIXME:!]]--"
+			if meta:get_int(k) .. "" == v .. "" then
+				t = "wrench.META_TYPE_INT"
+			elseif meta:get_float(k) .. "" == v .. "" then
+				t = "wrench.META_TYPE_FLOAT"
+			elseif meta:get_string(k) == v then
+				t = "wrench.META_TYPE_STRING"
+			end
+			local x = (k ~= "infotext" and k ~= "formspec") and
+				(" -- " .. v) or ""
+			print("\t\t" .. k .. " = " .. t .. "," .. x)
+		end
+		print("\t},")
+	end
+	print("})")
+end
+

--- a/debug.lua
+++ b/debug.lua
@@ -7,10 +7,10 @@ local get_keys = function(list)
 	return keys
 end
 
-local orig_wrench_pickup_node = wrench:pickup_node
-wrench:pickup_node = function(pos, player)
+local orig_wrench_pickup_node = wrench.pickup_node
+wrench.pickup_node = function(self, pos, player)
 	if not player:get_player_control().sneak then
-		return orig_wrench_pickup_node(pos, player)
+		return orig_wrench_pickup_node(self, pos, player)
 	end
 	local node = minetest.get_node(pos)
 	local def = minetest.registered_nodes[node.name]

--- a/functions.lua
+++ b/functions.lua
@@ -3,6 +3,8 @@ local S = rawget(_G, "intllib") and intllib.Getter() or function(s) return s end
 
 local SERIALIZATION_VERSION = 1
 
+local has_pipeworks = minetest.get_modpath("pipeworks")
+
 local errors = {
 	owned = S("Cannot pickup node. Owned by %s."),
 	full_inv = S("Not enough room in inventory to pickup node."),
@@ -101,6 +103,12 @@ function wrench.pickup_node(pos, player)
 	end
 	player_inv:add_item("main", stack)
 	minetest.remove_node(pos)
+	if def.after_pickup then
+		def.after_pickup(pos, node, meta:to_table(), player)
+	end
+	if has_pipeworks and minetest.registered_nodes[node.name].tube then
+		pipeworks.after_dig(pos)
+	end
 	return true
 end
 
@@ -141,6 +149,9 @@ function wrench.restore_node(pos, player, stack)
 	end
 	if def.after_place then
 		def.after_place(pos, player, stack)
+	end
+	if has_pipeworks and minetest.registered_nodes[data.name].tube then
+		pipeworks.after_place(pos)
 	end
 	return true
 end

--- a/functions.lua
+++ b/functions.lua
@@ -81,7 +81,7 @@ function wrench.pickup_node(pos, player)
 	if def.timer then
 		local timer = minetest.get_node_timer(pos)
 		local timeout = timer:get_timeout()
-		if timeout > 0 then
+		if timeout then
 			data.timer = {
 				timeout = timeout,
 				elapsed = timer:get_elapsed()
@@ -133,7 +133,11 @@ function wrench.restore_node(pos, player, stack)
 	end
 	if data.timer then
 		local timer = minetest.get_node_timer(pos)
-		timer:set(data.timer.timeout, data.timer.elapsed)
+		if data.timer.timeout == 0 then
+			timer:stop()
+		else
+			timer:set(data.timer.timeout, data.timer.elapsed)
+		end
 	end
 	if def.after_place then
 		def.after_place(pos, player, stack)

--- a/functions.lua
+++ b/functions.lua
@@ -38,9 +38,9 @@ local function get_description(def, pos, meta, node, player)
 	return S("%s with items"):format(minetest.registered_nodes[node.name].description)
 end
 
-function wrench:pickup_node(pos, player)
+function wrench.pickup_node(pos, player)
 	local node = minetest.get_node(pos)
-	local def = self.registered_nodes[node.name]
+	local def = wrench.registered_nodes[node.name]
 	if not def then
 		return
 	end
@@ -61,7 +61,7 @@ function wrench:pickup_node(pos, player)
 	for _, listname in pairs(def.lists or {}) do
 		local list = inv:get_list(listname)
 		for i, stack in pairs(list) do
-			if self.blacklisted_items[stack:get_name()] then
+			if wrench.blacklisted_items[stack:get_name()] then
 				local desc = stack:get_definition().description
 				return false, errors.bad_item:format(desc)
 			end
@@ -123,7 +123,7 @@ function wrench:pickup_node(pos, player)
 	return true
 end
 
-function wrench:restore_node(pos, player, stack)
+function wrench.restore_node(pos, player, stack)
 	if not stack then
 		return
 	end
@@ -131,7 +131,7 @@ function wrench:restore_node(pos, player, stack)
 	if not data then
 		return
 	end
-	local def = self.registered_nodes[data.name]
+	local def = wrench.registered_nodes[data.name]
 	if not def then
 		return
 	end

--- a/functions.lua
+++ b/functions.lua
@@ -78,6 +78,16 @@ function wrench.pickup_node(pos, player)
 			data.metas[name] = meta:get_int(name)
 		end
 	end
+	if def.timer then
+		local timer = minetest.get_node_timer(pos)
+		local timeout = timer:get_timeout()
+		if timeout > 0 then
+			data.timer = {
+				timeout = timeout,
+				elapsed = timer:get_elapsed()
+			}
+		end
+	end
 	local stack = ItemStack(node.name)
 	local item_meta = stack:get_meta()
 	item_meta:set_string("data", minetest.serialize(data))
@@ -120,6 +130,10 @@ function wrench.restore_node(pos, player, stack)
 		elseif meta_type == wrench.META_TYPE_STRING then
 			meta:set_string(name, value)
 		end
+	end
+	if data.timer then
+		local timer = minetest.get_node_timer(pos)
+		timer:set(data.timer.timeout, data.timer.elapsed)
 	end
 	if def.after_place then
 		def.after_place(pos, player, stack)

--- a/functions.lua
+++ b/functions.lua
@@ -81,12 +81,10 @@ function wrench.pickup_node(pos, player)
 	if def.timer then
 		local timer = minetest.get_node_timer(pos)
 		local timeout = timer:get_timeout()
-		if timeout then
-			data.timer = {
-				timeout = timeout,
-				elapsed = timer:get_elapsed()
-			}
-		end
+		data.timer = {
+			timeout = timeout,
+			elapsed = timer:get_elapsed()
+		}
 	end
 	local stack = ItemStack(node.name)
 	local item_meta = stack:get_meta()

--- a/functions.lua
+++ b/functions.lua
@@ -4,6 +4,7 @@ local S = rawget(_G, "intllib") and intllib.Getter() or function(s) return s end
 local SERIALIZATION_VERSION = 1
 
 local has_pipeworks = minetest.get_modpath("pipeworks")
+local has_mesecons = minetest.get_modpath("mesecons")
 
 local errors = {
 	owned = S("Cannot pickup node. Owned by %s."),
@@ -49,11 +50,8 @@ function wrench.pickup_node(pos, player)
 			return false, errors.owned:format(owner)
 		end
 	end
-	if def.drop then
-		node.name = def.drop
-	end
 	local data = {
-		name = node.name,
+		name = def.drop or node.name,
 		version = SERIALIZATION_VERSION,
 		lists = {},
 		metas = {},
@@ -90,7 +88,7 @@ function wrench.pickup_node(pos, player)
 			elapsed = timer:get_elapsed()
 		}
 	end
-	local stack = ItemStack(node.name)
+	local stack = ItemStack(def.drop or node.name)
 	local item_meta = stack:get_meta()
 	item_meta:set_string("data", minetest.serialize(data))
 	item_meta:set_string("description", get_description(def, pos, meta, node, player))
@@ -108,6 +106,9 @@ function wrench.pickup_node(pos, player)
 	end
 	if has_pipeworks and minetest.registered_nodes[node.name].tube then
 		pipeworks.after_dig(pos)
+	end
+	if has_mesecons and minetest.registered_nodes[node.name].mesecons then
+		mesecon.on_dignode(pos, node)
 	end
 	return true
 end

--- a/functions.lua
+++ b/functions.lua
@@ -47,18 +47,8 @@ function wrench.pickup_node(pos, player)
 			return false, errors.owned:format(owner)
 		end
 	end
-	-- TODO: Move handling for 'def.drop' to wrench.register_node()?
-	-- Unsupported types are then already noticed when registering
-	if type(def.drop) == "string" then
+	if def.drop then
 		node.name = def.drop
-	elseif type(def.drop) == "boolean" then
-		-- drop node name like digging
-		local drop = def.drop and minetest.registered_nodes[node.name].drop
-		if type(drop) == "string" then
-			node.name = drop
-		end
-	elseif def.drop then
-		minetest.log("warning", "wrench.pickup_node '"..node.name.."' invalid type for def.drop")
 	end
 	local data = {
 		name = node.name,

--- a/functions.lua
+++ b/functions.lua
@@ -89,10 +89,15 @@ function wrench.pickup_node(pos, player)
 			elapsed = timer:get_elapsed()
 		}
 	end
-	local stack = ItemStack(def.drop or node.name)
+	local drop_node = node
+	if def.drop then
+		drop_node = table.copy(node)
+		drop_node.name = def.drop
+	end
+	local stack = ItemStack(drop_node.name)
 	local item_meta = stack:get_meta()
 	item_meta:set_string("data", minetest.serialize(data))
-	item_meta:set_string("description", get_description(def, pos, meta, node, player))
+	item_meta:set_string("description", get_description(def, pos, meta, drop_node, player))
 	if #stack:to_string() > 65000 then
 		return false, errors.metadata
 	end

--- a/functions.lua
+++ b/functions.lua
@@ -47,10 +47,18 @@ function wrench.pickup_node(pos, player)
 			return false, errors.owned:format(owner)
 		end
 	end
-	local drop = def.drop and minetest.registered_nodes[node.name].drop
-	if drop then
+	-- TODO: Move handling for 'def.drop' to wrench.register_node()?
+	-- Unsupported types are then already noticed when registering
+	if type(def.drop) == "string" then
+		node.name = def.drop
+	elseif type(def.drop) == "boolean" then
 		-- drop node name like digging
-		node.name = drop
+		local drop = def.drop and minetest.registered_nodes[node.name].drop
+		if type(drop) == "string" then
+			node.name = drop
+		end
+	elseif def.drop then
+		minetest.log("warning", "wrench.pickup_node '"..node.name.."' invalid type for def.drop")
 	end
 	local data = {
 		name = node.name,
@@ -85,9 +93,8 @@ function wrench.pickup_node(pos, player)
 	end
 	if def.timer then
 		local timer = minetest.get_node_timer(pos)
-		local timeout = timer:get_timeout()
 		data.timer = {
-			timeout = timeout,
+			timeout = timer:get_timeout(),
 			elapsed = timer:get_elapsed()
 		}
 	end

--- a/functions.lua
+++ b/functions.lua
@@ -47,6 +47,11 @@ function wrench.pickup_node(pos, player)
 			return false, errors.owned:format(owner)
 		end
 	end
+	local drop = def.drop and minetest.registered_nodes[node.name].drop
+	if drop then
+		-- drop node name like digging
+		node.name = drop
+	end
 	local data = {
 		name = node.name,
 		version = SERIALIZATION_VERSION,

--- a/functions.lua
+++ b/functions.lua
@@ -5,6 +5,7 @@ local SERIALIZATION_VERSION = 1
 
 local has_pipeworks = minetest.get_modpath("pipeworks")
 local has_mesecons = minetest.get_modpath("mesecons")
+local has_digilines = minetest.get_modpath("digilines")
 
 local errors = {
 	owned = S("Cannot pickup node. Owned by %s."),
@@ -109,6 +110,9 @@ function wrench.pickup_node(pos, player)
 	end
 	if has_mesecons and minetest.registered_nodes[node.name].mesecons then
 		mesecon.on_dignode(pos, node)
+	end
+	if has_digilines and digilines.getspec(node) then
+		digilines.update_autoconnect(pos)
 	end
 	return true
 end

--- a/functions.lua
+++ b/functions.lua
@@ -105,13 +105,14 @@ function wrench.pickup_node(pos, player)
 	if def.after_pickup then
 		def.after_pickup(pos, node, meta:to_table(), player)
 	end
-	if has_pipeworks and minetest.registered_nodes[node.name].tube then
+	local node_def = minetest.registered_nodes[node.name]
+	if has_pipeworks and node_def.tube then
 		pipeworks.after_dig(pos)
 	end
-	if has_mesecons and minetest.registered_nodes[node.name].mesecons then
+	if has_mesecons and node_def.mesecons then
 		mesecon.on_dignode(pos, node)
 	end
-	if has_digilines and digilines.getspec(node) then
+	if has_digilines and node_def.digiline or node_def.digilines then
 		digilines.update_autoconnect(pos)
 	end
 	return true
@@ -155,8 +156,15 @@ function wrench.restore_node(pos, player, stack)
 	if def.after_place then
 		def.after_place(pos, player, stack)
 	end
-	if has_pipeworks and minetest.registered_nodes[data.name].tube then
+	local node_def = minetest.registered_nodes[data.name]
+	if has_pipeworks and node_def.tube then
 		pipeworks.after_place(pos)
+	end
+	if has_mesecons and node_def.mesecons then
+		mesecon.on_placenode(pos, minetest.get_node(pos))
+	end
+	if has_digilines and node_def.digiline or node_def.digilines then
+		digilines.update_autoconnect(pos)
 	end
 	return true
 end

--- a/functions.lua
+++ b/functions.lua
@@ -38,9 +38,9 @@ local function get_description(def, pos, meta, node, player)
 	return S("%s with items"):format(minetest.registered_nodes[node.name].description)
 end
 
-function wrench.pickup_node(pos, player)
+function wrench:pickup_node(pos, player)
 	local node = minetest.get_node(pos)
-	local def = wrench.registered_nodes[node.name]
+	local def = self.registered_nodes[node.name]
 	if not def then
 		return
 	end
@@ -61,7 +61,7 @@ function wrench.pickup_node(pos, player)
 	for _, listname in pairs(def.lists or {}) do
 		local list = inv:get_list(listname)
 		for i, stack in pairs(list) do
-			if wrench.blacklisted_items[stack:get_name()] then
+			if self.blacklisted_items[stack:get_name()] then
 				local desc = stack:get_definition().description
 				return false, errors.bad_item:format(desc)
 			end
@@ -123,7 +123,7 @@ function wrench.pickup_node(pos, player)
 	return true
 end
 
-function wrench.restore_node(pos, player, stack)
+function wrench:restore_node(pos, player, stack)
 	if not stack then
 		return
 	end
@@ -131,7 +131,7 @@ function wrench.restore_node(pos, player, stack)
 	if not data then
 		return
 	end
-	local def = wrench.registered_nodes[data.name]
+	local def = self.registered_nodes[data.name]
 	if not def then
 		return
 	end

--- a/init.lua
+++ b/init.lua
@@ -48,7 +48,7 @@ local mods = {
 	"default",
 	"digtron",
 	"drawers",
-        "pipeworks",
+	"pipeworks",
 	"technic",
 	"technic_chests",
 	"technic_cnc",

--- a/init.lua
+++ b/init.lua
@@ -51,6 +51,7 @@ local mods = {
 	"technic",
 	"technic_chests",
 	"technic_cnc",
+	"xdecor",
 }
 
 for _, modname in pairs(mods) do

--- a/init.lua
+++ b/init.lua
@@ -48,6 +48,7 @@ local mods = {
 	"default",
 	"digtron",
 	"drawers",
+	"more_chests",
 	"pipeworks",
 	"technic",
 	"technic_chests",

--- a/init.lua
+++ b/init.lua
@@ -18,7 +18,6 @@ function wrench.register_node(name, def)
 	assert(type(def) == "table", "wrench.register_node invalid type for def")
 	local node_def = minetest.registered_nodes[name]
 	if node_def then
-		wrench.registered_nodes[name] = table.copy(def)
 		local old_after_place = node_def.after_place_node
 		minetest.override_item(name, {
 			after_place_node = function(...)
@@ -27,6 +26,20 @@ function wrench.register_node(name, def)
 				end
 			end
 		})
+		def = table.copy(def)
+		if def.drop == true and type(node_def.drop) == "string" then
+			def.drop = node_def.drop
+		elseif def.drop and type(def.drop) ~= "string" then
+			minetest.log("warning", "Ignoring invalid type for drop in definition for "..name)
+			def.drop = nil
+		end
+		if def.drop and not wrench.registered_nodes[def.drop] then
+			if def.drop ~= name then
+				minetest.log("warning", "Ignoring unsupported node for drop in definition for "..name)
+			end
+			def.drop = nil
+		end
+		wrench.registered_nodes[name] = def
 	else
 		minetest.log("warning", "Attempt to register unknown node for wrench: "..name)
 	end

--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,7 @@ local mods = {
 	"bones",
 	"connected_chests",
 	"default",
+	"digilines",
 	"digtron",
 	"drawers",
 	"mesecons",

--- a/init.lua
+++ b/init.lua
@@ -43,6 +43,7 @@ function wrench.blacklist_item(name)
 end
 
 local mods = {
+	"bones",
 	"default",
 	"digtron",
 	"drawers",

--- a/init.lua
+++ b/init.lua
@@ -44,6 +44,7 @@ end
 
 local mods = {
 	"bones",
+	"connected_chests",
 	"default",
 	"digtron",
 	"drawers",

--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,7 @@ local mods = {
 	"technic",
 	"technic_chests",
 	"technic_cnc",
+	"vessels",
 	"xdecor",
 }
 

--- a/init.lua
+++ b/init.lua
@@ -9,10 +9,10 @@ wrench = {
 	META_TYPE_INT = 3,
 }
 
-dofile(modpath.."/api.lua")
+dofile(modpath.."/legacy.lua")
 dofile(modpath.."/functions.lua")
 dofile(modpath.."/tool.lua")
-dofile(modpath.."/legacy.lua")
+dofile(modpath.."/api.lua")
 
 local mods = {
 	"3d_armor_stand",

--- a/init.lua
+++ b/init.lua
@@ -2,6 +2,7 @@
 local modpath = minetest.get_modpath("wrench")
 
 wrench = {
+	plus = true,
 	registered_nodes = {},
 	blacklisted_items = {},
 	META_TYPE_FLOAT = 1,

--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ dofile(modpath.."/api.lua")
 
 local mods = {
 	"3d_armor_stand",
+	"bees",
 	"biofuel",
 	"bones",
 	"connected_chests",

--- a/init.lua
+++ b/init.lua
@@ -43,6 +43,7 @@ function wrench.blacklist_item(name)
 end
 
 local mods = {
+	"3d_armor_stand",
 	"bones",
 	"connected_chests",
 	"default",

--- a/init.lua
+++ b/init.lua
@@ -35,3 +35,7 @@ for _, modname in pairs(mods) do
 		dofile(modpath.."/nodes/"..modname..".lua")
 	end
 end
+
+if minetest.settings:get_bool("wrench.enable_debug", false) then
+	dofile(modpath.."/debug.lua")
+end

--- a/init.lua
+++ b/init.lua
@@ -25,6 +25,7 @@ local mods = {
 	"digtron",
 	"drawers",
 	"mesecons",
+	"mobs",
 	"more_chests",
 	"pipeworks",
 	"technic",

--- a/init.lua
+++ b/init.lua
@@ -12,48 +12,7 @@ wrench = {
 dofile(modpath.."/legacy.lua")
 dofile(modpath.."/functions.lua")
 dofile(modpath.."/tool.lua")
-
-function wrench.register_node(name, def)
-	assert(type(name) == "string", "wrench.register_node invalid type for name")
-	assert(type(def) == "table", "wrench.register_node invalid type for def")
-	local node_def = minetest.registered_nodes[name]
-	if node_def then
-		local old_after_place = node_def.after_place_node
-		minetest.override_item(name, {
-			after_place_node = function(...)
-				if not wrench.restore_node(...) and old_after_place then
-					return old_after_place(...)
-				end
-			end
-		})
-		def = table.copy(def)
-		if def.drop == true and type(node_def.drop) == "string" then
-			def.drop = node_def.drop
-		elseif def.drop and type(def.drop) ~= "string" then
-			minetest.log("warning", "Ignoring invalid type for drop in definition for "..name)
-			def.drop = nil
-		end
-		if def.drop and not wrench.registered_nodes[def.drop] then
-			if def.drop ~= name then
-				minetest.log("warning", "Ignoring unsupported node for drop in definition for "..name)
-			end
-			def.drop = nil
-		end
-		wrench.registered_nodes[name] = def
-	else
-		minetest.log("warning", "Attempt to register unknown node for wrench: "..name)
-	end
-end
-
-function wrench.blacklist_item(name)
-	assert(type(name) == "string", "wrench:blacklist_item invalid type for name")
-	local node_def = minetest.registered_items[name]
-	if node_def then
-		wrench.blacklisted_items[name] = true
-	else
-		minetest.log("warning", "Attempt to blacklist unknown item for wrench: "..name)
-	end
-end
+dofile(modpath.."/api.lua")
 
 local mods = {
 	"3d_armor_stand",

--- a/init.lua
+++ b/init.lua
@@ -9,10 +9,10 @@ wrench = {
 	META_TYPE_INT = 3,
 }
 
-dofile(modpath.."/legacy.lua")
+dofile(modpath.."/api.lua")
 dofile(modpath.."/functions.lua")
 dofile(modpath.."/tool.lua")
-dofile(modpath.."/api.lua")
+dofile(modpath.."/legacy.lua")
 
 local mods = {
 	"3d_armor_stand",

--- a/init.lua
+++ b/init.lua
@@ -48,6 +48,7 @@ local mods = {
 	"default",
 	"digtron",
 	"drawers",
+        "pipeworks",
 	"technic",
 	"technic_chests",
 	"technic_cnc",

--- a/init.lua
+++ b/init.lua
@@ -16,6 +16,7 @@ dofile(modpath.."/api.lua")
 
 local mods = {
 	"3d_armor_stand",
+	"biofuel",
 	"bones",
 	"connected_chests",
 	"default",

--- a/init.lua
+++ b/init.lua
@@ -23,6 +23,7 @@ local mods = {
 	"default",
 	"digtron",
 	"drawers",
+	"mesecons",
 	"more_chests",
 	"pipeworks",
 	"technic",

--- a/legacy.lua
+++ b/legacy.lua
@@ -1,16 +1,4 @@
 
--- Compatibility for old function signature
-
-local register_node = wrench.register_node
-
-function wrench.register_node(self, ...)
-	if self == wrench then
-		register_node(...)
-	else
-		register_node(self, ...)
-	end
-end
-
 -- Register aliases for old wrench:picked_up_* nodes
 
 local all_nodes = {

--- a/legacy.lua
+++ b/legacy.lua
@@ -119,7 +119,7 @@ local all_nodes = {
 
 for mod, nodes in pairs(all_nodes) do
 	if minetest.get_modpath(mod) then
-		for _,n in pairs(nodes) do
+		for _, n in pairs(nodes) do
 			minetest.register_alias("wrench:picked_up_"..n:gsub(":", "_"), n)
 		end
 	end

--- a/legacy.lua
+++ b/legacy.lua
@@ -1,4 +1,16 @@
 
+-- Compatibility for old function signature
+
+local register_node = wrench.register_node
+
+function wrench.register_node(self, ...)
+	if self == wrench then
+		register_node(...)
+	else
+		register_node(self, ...)
+	end
+end
+
 -- Register aliases for old wrench:picked_up_* nodes
 
 local all_nodes = {

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wrench
-optional_depends = technic, technic_chests, technic_worldgen, intllib, drawers, default, digtron
+optional_depends = bones, default, digtron, drawers, intllib, technic, technic_chests, technic_worldgen

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wrench
-optional_depends = bones, connected_chests, default, digtron, drawers, intllib, technic, technic_chests, technic_worldgen
+optional_depends = bones, connected_chests, default, digtron, drawers, intllib, technic, technic_chests, technic_worldgen, xdecor

--- a/mod.conf
+++ b/mod.conf
@@ -1,6 +1,7 @@
 name = wrench
 optional_depends = """
 	3d_armor_stand,
+	biofuel,
 	bones,
 	connected_chests,
 	default,

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wrench
-optional_depends = bones, connected_chests, default, digtron, drawers, intllib, technic, technic_chests, technic_worldgen, xdecor
+optional_depends = bones, connected_chests, default, digtron, drawers, intllib, pipeworks, technic, technic_chests, technic_worldgen, xdecor

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,14 @@
 name = wrench
-optional_depends = bones, connected_chests, default, digtron, drawers, intllib, pipeworks, technic, technic_chests, technic_worldgen, xdecor
+optional_depends = """
+	bones,
+	connected_chests,
+	default,
+	digtron,
+	drawers,
+	intllib,
+	pipeworks,
+	technic,
+	technic_chests,
+	technic_worldgen,
+	xdecor,
+"""

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = wrench
-optional_depends = bones, default, digtron, drawers, intllib, technic, technic_chests, technic_worldgen
+optional_depends = bones, connected_chests, default, digtron, drawers, intllib, technic, technic_chests, technic_worldgen

--- a/mod.conf
+++ b/mod.conf
@@ -1,14 +1,17 @@
 name = wrench
 optional_depends = """
+	3d_armor_stand,
 	bones,
 	connected_chests,
 	default,
 	digtron,
 	drawers,
 	intllib,
+	more_chests,
 	pipeworks,
 	technic,
 	technic_chests,
+	technic_cnc,
 	technic_worldgen,
 	xdecor,
 """

--- a/nodes/3d_armor_stand.lua
+++ b/nodes/3d_armor_stand.lua
@@ -1,0 +1,41 @@
+
+-- Register wrench support for armor stands
+
+local def = minetest.registered_nodes["3d_armor_stand:armor_stand"]
+
+local add_entity_and_node = def and def.after_place_node
+local update_entity = def and def.on_metadata_inventory_put
+
+local lists = {
+	"armor_head",
+	"armor_torso",
+	"armor_legs",
+	"armor_feet",
+}
+
+local function after_place(pos, player)
+	add_entity_and_node(pos, player)
+	update_entity(pos)
+end
+
+local function description(pos, meta, node)
+	local desc = minetest.registered_nodes[node.name].description
+	return string.format("%s with armor", desc)
+end
+
+wrench.register_node("3d_armor_stand:armor_stand", {
+	lists = lists,
+	after_place = after_place,
+	description = description,
+})
+
+wrench.register_node("3d_armor_stand:locked_armor_stand", {
+	lists = lists,
+	metas = {
+		owner = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+	},
+	owned = true,
+	after_place = after_place,
+	description = description,
+})

--- a/nodes/3d_armor_stand.lua
+++ b/nodes/3d_armor_stand.lua
@@ -23,13 +23,13 @@ local function description(pos, meta, node)
 	return string.format("%s with armor", desc)
 end
 
-wrench:register_node("3d_armor_stand:armor_stand", {
+wrench.register_node("3d_armor_stand:armor_stand", {
 	lists = lists,
 	after_place = after_place,
 	description = description,
 })
 
-wrench:register_node("3d_armor_stand:locked_armor_stand", {
+wrench.register_node("3d_armor_stand:locked_armor_stand", {
 	lists = lists,
 	metas = {
 		owner = wrench.META_TYPE_STRING,

--- a/nodes/3d_armor_stand.lua
+++ b/nodes/3d_armor_stand.lua
@@ -23,13 +23,13 @@ local function description(pos, meta, node)
 	return string.format("%s with armor", desc)
 end
 
-wrench.register_node("3d_armor_stand:armor_stand", {
+wrench:register_node("3d_armor_stand:armor_stand", {
 	lists = lists,
 	after_place = after_place,
 	description = description,
 })
 
-wrench.register_node("3d_armor_stand:locked_armor_stand", {
+wrench:register_node("3d_armor_stand:locked_armor_stand", {
 	lists = lists,
 	metas = {
 		owner = wrench.META_TYPE_STRING,

--- a/nodes/bees.lua
+++ b/nodes/bees.lua
@@ -1,0 +1,10 @@
+
+-- Register wrench support for bees
+
+wrench.register_node("bees:hive_wild", {
+	timer = true,
+	lists = {"combs", "queen"},
+	metas = {
+		agressive = wrench.META_TYPE_INT,
+	},
+})

--- a/nodes/bees.lua
+++ b/nodes/bees.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for bees
 
-wrench.register_node("bees:hive_wild", {
+wrench:register_node("bees:hive_wild", {
 	timer = true,
 	lists = {"combs", "queen"},
 	metas = {

--- a/nodes/bees.lua
+++ b/nodes/bees.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for bees
 
-wrench:register_node("bees:hive_wild", {
+wrench.register_node("bees:hive_wild", {
 	timer = true,
 	lists = {"combs", "queen"},
 	metas = {

--- a/nodes/biofuel.lua
+++ b/nodes/biofuel.lua
@@ -17,5 +17,4 @@ wrench.register_node("biofuel:refinery_active", {
 		progress = wrench.META_TYPE_INT,
 	},
 	timer = true,
-	drop = "biofuel:refinery",
 })

--- a/nodes/biofuel.lua
+++ b/nodes/biofuel.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for biofuel refinery
 
-wrench:register_node("biofuel:refinery", {
+wrench.register_node("biofuel:refinery", {
 	lists = {"src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -10,7 +10,7 @@ wrench:register_node("biofuel:refinery", {
 	timer = true,
 })
 
-wrench:register_node("biofuel:refinery_active", {
+wrench.register_node("biofuel:refinery_active", {
 	lists = {"src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/biofuel.lua
+++ b/nodes/biofuel.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for biofuel refinery
 
-wrench.register_node("biofuel:refinery", {
+wrench:register_node("biofuel:refinery", {
 	lists = {"src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -10,7 +10,7 @@ wrench.register_node("biofuel:refinery", {
 	timer = true,
 })
 
-wrench.register_node("biofuel:refinery_active", {
+wrench:register_node("biofuel:refinery_active", {
 	lists = {"src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/biofuel.lua
+++ b/nodes/biofuel.lua
@@ -1,0 +1,21 @@
+
+-- Register wrench support for biofuel refinery
+
+wrench.register_node("biofuel:refinery", {
+	lists = {"src", "dst"},
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		progress = wrench.META_TYPE_INT,
+	},
+	timer = true,
+})
+
+wrench.register_node("biofuel:refinery_active", {
+	lists = {"src", "dst"},
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		progress = wrench.META_TYPE_INT,
+	},
+	timer = true,
+	drop = "biofuel:refinery",
+})

--- a/nodes/bones.lua
+++ b/nodes/bones.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for bones
 
-wrench:register_node("bones:bones", {
+wrench.register_node("bones:bones", {
 	lists = {"main"},
 	metas = {
 			owner = wrench.META_TYPE_STRING,

--- a/nodes/bones.lua
+++ b/nodes/bones.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for bones
 
-wrench.register_node("bones:bones", {
+wrench:register_node("bones:bones", {
 	lists = {"main"},
 	metas = {
 			owner = wrench.META_TYPE_STRING,

--- a/nodes/bones.lua
+++ b/nodes/bones.lua
@@ -3,11 +3,11 @@
 
 wrench.register_node("bones:bones", {
 	lists = {"main"},
-        metas = {
-                owner = wrench.META_TYPE_STRING,
-                infotext = wrench.META_TYPE_STRING,
-                formspec = wrench.META_TYPE_STRING,
-                time = wrench.META_TYPE_INT,
-        },
-        owned = true,
+	metas = {
+			owner = wrench.META_TYPE_STRING,
+			infotext = wrench.META_TYPE_STRING,
+			formspec = wrench.META_TYPE_STRING,
+			time = wrench.META_TYPE_INT,
+	},
+	owned = true,
 })

--- a/nodes/bones.lua
+++ b/nodes/bones.lua
@@ -1,0 +1,13 @@
+
+-- Register wrench support for bones
+
+wrench.register_node("bones:bones", {
+	lists = {"main"},
+        metas = {
+                owner = wrench.META_TYPE_STRING,
+                infotext = wrench.META_TYPE_STRING,
+                formspec = wrench.META_TYPE_STRING,
+                time = wrench.META_TYPE_INT,
+        },
+        owned = true,
+})

--- a/nodes/connected_chests.lua
+++ b/nodes/connected_chests.lua
@@ -1,0 +1,29 @@
+
+-- Register wrench support for connected_chests
+
+wrench.register_node("default:chest_connected_left", {
+	lists = {"main"},
+})
+
+wrench.register_node("default:chest_connected_right", {
+	lists = {"main"},
+})
+
+wrench.register_node("default:chest_locked_connected_left", {
+	lists = {"main"},
+        metas = {
+                owner = wrench.META_TYPE_STRING,
+                infotext = wrench.META_TYPE_STRING
+        },
+        owned = true,
+})
+
+wrench.register_node("default:chest_locked_connected_right", {
+	lists = {"main"},
+        metas = {
+                owner = wrench.META_TYPE_STRING,
+                infotext = wrench.META_TYPE_STRING
+        },
+        owned = true,
+
+})

--- a/nodes/connected_chests.lua
+++ b/nodes/connected_chests.lua
@@ -1,15 +1,15 @@
 
 -- Register wrench support for connected_chests
 
-wrench.register_node("default:chest_connected_left", {
+wrench:register_node("default:chest_connected_left", {
 	lists = {"main"},
 })
 
-wrench.register_node("default:chest_connected_right", {
+wrench:register_node("default:chest_connected_right", {
 	lists = {"main"},
 })
 
-wrench.register_node("default:chest_locked_connected_left", {
+wrench:register_node("default:chest_locked_connected_left", {
 	lists = {"main"},
 	metas = {
 			owner = wrench.META_TYPE_STRING,
@@ -18,7 +18,7 @@ wrench.register_node("default:chest_locked_connected_left", {
 	owned = true,
 })
 
-wrench.register_node("default:chest_locked_connected_right", {
+wrench:register_node("default:chest_locked_connected_right", {
 	lists = {"main"},
 	metas = {
 			owner = wrench.META_TYPE_STRING,

--- a/nodes/connected_chests.lua
+++ b/nodes/connected_chests.lua
@@ -1,15 +1,15 @@
 
 -- Register wrench support for connected_chests
 
-wrench:register_node("default:chest_connected_left", {
+wrench.register_node("default:chest_connected_left", {
 	lists = {"main"},
 })
 
-wrench:register_node("default:chest_connected_right", {
+wrench.register_node("default:chest_connected_right", {
 	lists = {"main"},
 })
 
-wrench:register_node("default:chest_locked_connected_left", {
+wrench.register_node("default:chest_locked_connected_left", {
 	lists = {"main"},
 	metas = {
 			owner = wrench.META_TYPE_STRING,
@@ -18,7 +18,7 @@ wrench:register_node("default:chest_locked_connected_left", {
 	owned = true,
 })
 
-wrench:register_node("default:chest_locked_connected_right", {
+wrench.register_node("default:chest_locked_connected_right", {
 	lists = {"main"},
 	metas = {
 			owner = wrench.META_TYPE_STRING,

--- a/nodes/connected_chests.lua
+++ b/nodes/connected_chests.lua
@@ -11,19 +11,18 @@ wrench.register_node("default:chest_connected_right", {
 
 wrench.register_node("default:chest_locked_connected_left", {
 	lists = {"main"},
-        metas = {
-                owner = wrench.META_TYPE_STRING,
-                infotext = wrench.META_TYPE_STRING
-        },
-        owned = true,
+	metas = {
+			owner = wrench.META_TYPE_STRING,
+			infotext = wrench.META_TYPE_STRING
+	},
+	owned = true,
 })
 
 wrench.register_node("default:chest_locked_connected_right", {
 	lists = {"main"},
-        metas = {
-                owner = wrench.META_TYPE_STRING,
-                infotext = wrench.META_TYPE_STRING
-        },
-        owned = true,
-
+	metas = {
+			owner = wrench.META_TYPE_STRING,
+			infotext = wrench.META_TYPE_STRING
+	},
+	owned = true,
 })

--- a/nodes/default.lua
+++ b/nodes/default.lua
@@ -1,15 +1,25 @@
 
 -- Register nodes from default / minetest_game
 
+local has_pipeworks = minetest.get_modpath("pipeworks")
+local splitstacks = has_pipeworks and wrench.META_TYPE_INT
+local formspec = has_pipeworks and wrench.META_TYPE_STRING
+
 wrench.register_node("default:chest", {
 	lists = {"main"},
+	metas = {
+		splitstacks = splitstacks,
+		formspec = formspec,
+	}
 })
 
 wrench.register_node("default:chest_locked", {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
-		infotext = wrench.META_TYPE_STRING
+		infotext = wrench.META_TYPE_STRING,
+		splitstacks = splitstacks,
+		formspec = formspec,
 	},
 	owned = true,
 })
@@ -21,7 +31,9 @@ wrench.register_node("default:furnace", {
 		fuel_totaltime = wrench.META_TYPE_FLOAT,
 		fuel_time = wrench.META_TYPE_FLOAT,
 		src_totaltime = wrench.META_TYPE_FLOAT,
-		src_time = wrench.META_TYPE_FLOAT
+		src_time = wrench.META_TYPE_FLOAT,
+		splitstacks = splitstacks,
+		formspec = formspec,
 	},
 })
 
@@ -32,9 +44,10 @@ wrench.register_node("default:furnace_active", {
 		fuel_totaltime = wrench.META_TYPE_FLOAT,
 		fuel_time = wrench.META_TYPE_FLOAT,
 		src_totaltime = wrench.META_TYPE_FLOAT,
-		src_time = wrench.META_TYPE_FLOAT
+		src_time = wrench.META_TYPE_FLOAT,
+		splitstacks = splitstacks,
+		formspec = formspec,
 	},
-	store_meta_always = true,
 })
 
 local function get_sign_description(pos, meta, node)

--- a/nodes/default.lua
+++ b/nodes/default.lua
@@ -5,7 +5,7 @@ local has_pipeworks = minetest.get_modpath("pipeworks")
 local splitstacks = has_pipeworks and wrench.META_TYPE_INT
 local formspec = has_pipeworks and wrench.META_TYPE_STRING
 
-wrench.register_node("default:chest", {
+wrench:register_node("default:chest", {
 	lists = {"main"},
 	metas = {
 		splitstacks = splitstacks,
@@ -13,7 +13,7 @@ wrench.register_node("default:chest", {
 	}
 })
 
-wrench.register_node("default:chest_locked", {
+wrench:register_node("default:chest_locked", {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
@@ -24,7 +24,7 @@ wrench.register_node("default:chest_locked", {
 	owned = true,
 })
 
-wrench.register_node("default:furnace", {
+wrench:register_node("default:furnace", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -37,7 +37,7 @@ wrench.register_node("default:furnace", {
 	},
 })
 
-wrench.register_node("default:furnace_active", {
+wrench:register_node("default:furnace_active", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -59,7 +59,7 @@ local function get_sign_description(pos, meta, node)
 	return string.format("%s with text \"%s\"", desc, text)
 end
 
-wrench.register_node("default:sign_wall_wood", {
+wrench:register_node("default:sign_wall_wood", {
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		text = wrench.META_TYPE_STRING
@@ -67,7 +67,7 @@ wrench.register_node("default:sign_wall_wood", {
 	description = get_sign_description,
 })
 
-wrench.register_node("default:sign_wall_steel", {
+wrench:register_node("default:sign_wall_steel", {
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		text = wrench.META_TYPE_STRING

--- a/nodes/default.lua
+++ b/nodes/default.lua
@@ -5,7 +5,7 @@ local has_pipeworks = minetest.get_modpath("pipeworks")
 local splitstacks = has_pipeworks and wrench.META_TYPE_INT
 local formspec = has_pipeworks and wrench.META_TYPE_STRING
 
-wrench:register_node("default:chest", {
+wrench.register_node("default:chest", {
 	lists = {"main"},
 	metas = {
 		splitstacks = splitstacks,
@@ -13,7 +13,7 @@ wrench:register_node("default:chest", {
 	}
 })
 
-wrench:register_node("default:chest_locked", {
+wrench.register_node("default:chest_locked", {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
@@ -24,7 +24,7 @@ wrench:register_node("default:chest_locked", {
 	owned = true,
 })
 
-wrench:register_node("default:furnace", {
+wrench.register_node("default:furnace", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -37,7 +37,7 @@ wrench:register_node("default:furnace", {
 	},
 })
 
-wrench:register_node("default:furnace_active", {
+wrench.register_node("default:furnace_active", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -59,7 +59,7 @@ local function get_sign_description(pos, meta, node)
 	return string.format("%s with text \"%s\"", desc, text)
 end
 
-wrench:register_node("default:sign_wall_wood", {
+wrench.register_node("default:sign_wall_wood", {
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		text = wrench.META_TYPE_STRING
@@ -67,7 +67,7 @@ wrench:register_node("default:sign_wall_wood", {
 	description = get_sign_description,
 })
 
-wrench:register_node("default:sign_wall_steel", {
+wrench.register_node("default:sign_wall_steel", {
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		text = wrench.META_TYPE_STRING

--- a/nodes/digilines.lua
+++ b/nodes/digilines.lua
@@ -6,7 +6,7 @@ local desc_channel = function(pos, meta, node, player)
 	return string.format("%s with channel \"%s\"", desc, meta:get_string("channel"))
 end
 
-wrench.register_node("digilines:chest", {
+wrench:register_node("digilines:chest", {
 	lists = {"main"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -15,7 +15,7 @@ wrench.register_node("digilines:chest", {
 	},
 })
 
-wrench.register_node("digilines:lightsensor", {
+wrench:register_node("digilines:lightsensor", {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		channel = wrench.META_TYPE_STRING,
@@ -23,7 +23,7 @@ wrench.register_node("digilines:lightsensor", {
 	description = desc_channel,
 })
 
-wrench.register_node("digilines:rtc", {
+wrench:register_node("digilines:rtc", {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		channel = wrench.META_TYPE_STRING,
@@ -31,7 +31,7 @@ wrench.register_node("digilines:rtc", {
 	description = desc_channel,
 })
 
-wrench.register_node("digilines:lcd", {
+wrench:register_node("digilines:lcd", {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		channel = wrench.META_TYPE_STRING,

--- a/nodes/digilines.lua
+++ b/nodes/digilines.lua
@@ -3,7 +3,7 @@
 
 local desc_channel = function(pos, meta, node, player)
 	local desc = minetest.registered_nodes[node.name].description
-	return string.format("%s channel: %s", desc, meta:get_string("channel") or "")
+	return string.format("%s with channel \"%s\"", desc, meta:get_string("channel"))
 end
 
 wrench.register_node("digilines:chest", {

--- a/nodes/digilines.lua
+++ b/nodes/digilines.lua
@@ -6,7 +6,7 @@ local desc_channel = function(pos, meta, node, player)
 	return string.format("%s with channel \"%s\"", desc, meta:get_string("channel"))
 end
 
-wrench:register_node("digilines:chest", {
+wrench.register_node("digilines:chest", {
 	lists = {"main"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -15,7 +15,7 @@ wrench:register_node("digilines:chest", {
 	},
 })
 
-wrench:register_node("digilines:lightsensor", {
+wrench.register_node("digilines:lightsensor", {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		channel = wrench.META_TYPE_STRING,
@@ -23,7 +23,7 @@ wrench:register_node("digilines:lightsensor", {
 	description = desc_channel,
 })
 
-wrench:register_node("digilines:rtc", {
+wrench.register_node("digilines:rtc", {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		channel = wrench.META_TYPE_STRING,
@@ -31,7 +31,7 @@ wrench:register_node("digilines:rtc", {
 	description = desc_channel,
 })
 
-wrench:register_node("digilines:lcd", {
+wrench.register_node("digilines:lcd", {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		channel = wrench.META_TYPE_STRING,

--- a/nodes/digilines.lua
+++ b/nodes/digilines.lua
@@ -1,0 +1,40 @@
+
+-- Register wrench support for digilines
+
+local desc_channel = function(pos, meta, node, player)
+	local desc = minetest.registered_nodes[node.name].description
+	return string.format("%s channel: %s", desc, meta:get_string("channel") or "")
+end
+
+wrench.register_node("digilines:chest", {
+	lists = {"main"},
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+		channel = wrench.META_TYPE_STRING,
+	},
+})
+
+wrench.register_node("digilines:lightsensor", {
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		channel = wrench.META_TYPE_STRING,
+	},
+	description = desc_channel,
+})
+
+wrench.register_node("digilines:rtc", {
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		channel = wrench.META_TYPE_STRING,
+	},
+	description = desc_channel,
+})
+
+wrench.register_node("digilines:lcd", {
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		channel = wrench.META_TYPE_STRING,
+	},
+	description = desc_channel,
+})

--- a/nodes/digtron.lua
+++ b/nodes/digtron.lua
@@ -1,23 +1,23 @@
 
 -- Register wrench support for digtron
 
-wrench.register_node("digtron:battery_holder", {
+wrench:register_node("digtron:battery_holder", {
 	lists = {"batteries"}
 })
 
-wrench.register_node("digtron:inventory", {
+wrench:register_node("digtron:inventory", {
 	lists = {"main"}
 })
 
-wrench.register_node("digtron:fuelstore", {
+wrench:register_node("digtron:fuelstore", {
 	lists = {"fuel"}
 })
 
-wrench.register_node("digtron:combined_storage", {
+wrench:register_node("digtron:combined_storage", {
 	lists = {"main", "fuel"}
 })
 
 -- Blacklist loaded crates to prevent nesting of inventories
 
-wrench.blacklist_item("digtron:loaded_crate")
-wrench.blacklist_item("digtron:loaded_locked_crate")
+wrench:blacklist_item("digtron:loaded_crate")
+wrench:blacklist_item("digtron:loaded_locked_crate")

--- a/nodes/digtron.lua
+++ b/nodes/digtron.lua
@@ -1,23 +1,23 @@
 
 -- Register wrench support for digtron
 
-wrench:register_node("digtron:battery_holder", {
+wrench.register_node("digtron:battery_holder", {
 	lists = {"batteries"}
 })
 
-wrench:register_node("digtron:inventory", {
+wrench.register_node("digtron:inventory", {
 	lists = {"main"}
 })
 
-wrench:register_node("digtron:fuelstore", {
+wrench.register_node("digtron:fuelstore", {
 	lists = {"fuel"}
 })
 
-wrench:register_node("digtron:combined_storage", {
+wrench.register_node("digtron:combined_storage", {
 	lists = {"main", "fuel"}
 })
 
 -- Blacklist loaded crates to prevent nesting of inventories
 
-wrench:blacklist_item("digtron:loaded_crate")
-wrench:blacklist_item("digtron:loaded_locked_crate")
+wrench.blacklist_item("digtron:loaded_crate")
+wrench.blacklist_item("digtron:loaded_locked_crate")

--- a/nodes/drawers.lua
+++ b/nodes/drawers.lua
@@ -20,17 +20,17 @@ for _, drawer_type in ipairs({1, 2, 4}) do
 			suffix = i
 		end
 
-		def.metas["name" .. suffix] = STRING
-		def.metas["count" .. suffix] = INT
-		def.metas["max_count" .. suffix] = INT
-		def.metas["base_stack_max" .. suffix] = INT
-		def.metas["entity_infotext" .. suffix] = STRING
-		def.metas["stack_max_factor" .. suffix] = INT
+		def.metas["name"..suffix] = STRING
+		def.metas["count"..suffix] = INT
+		def.metas["max_count"..suffix] = INT
+		def.metas["base_stack_max"..suffix] = INT
+		def.metas["entity_infotext"..suffix] = STRING
+		def.metas["stack_max_factor"..suffix] = INT
 	end
 
-	wrench.register_node("drawers:wood" .. drawer_type, def)
-	wrench.register_node("drawers:acacia_wood" .. drawer_type, def)
-	wrench.register_node("drawers:aspen_wood" .. drawer_type, def)
-	wrench.register_node("drawers:junglewood" .. drawer_type, def)
-	wrench.register_node("drawers:pine_wood" .. drawer_type, def)
+	wrench.register_node("drawers:wood"..drawer_type, def)
+	wrench.register_node("drawers:acacia_wood"..drawer_type, def)
+	wrench.register_node("drawers:aspen_wood"..drawer_type, def)
+	wrench.register_node("drawers:junglewood"..drawer_type, def)
+	wrench.register_node("drawers:pine_wood"..drawer_type, def)
 end

--- a/nodes/drawers.lua
+++ b/nodes/drawers.lua
@@ -28,9 +28,9 @@ for _, drawer_type in ipairs({1, 2, 4}) do
 		def.metas["stack_max_factor"..suffix] = INT
 	end
 
-	wrench:register_node("drawers:wood"..drawer_type, def)
-	wrench:register_node("drawers:acacia_wood"..drawer_type, def)
-	wrench:register_node("drawers:aspen_wood"..drawer_type, def)
-	wrench:register_node("drawers:junglewood"..drawer_type, def)
-	wrench:register_node("drawers:pine_wood"..drawer_type, def)
+	wrench.register_node("drawers:wood"..drawer_type, def)
+	wrench.register_node("drawers:acacia_wood"..drawer_type, def)
+	wrench.register_node("drawers:aspen_wood"..drawer_type, def)
+	wrench.register_node("drawers:junglewood"..drawer_type, def)
+	wrench.register_node("drawers:pine_wood"..drawer_type, def)
 end

--- a/nodes/drawers.lua
+++ b/nodes/drawers.lua
@@ -28,9 +28,9 @@ for _, drawer_type in ipairs({1, 2, 4}) do
 		def.metas["stack_max_factor"..suffix] = INT
 	end
 
-	wrench.register_node("drawers:wood"..drawer_type, def)
-	wrench.register_node("drawers:acacia_wood"..drawer_type, def)
-	wrench.register_node("drawers:aspen_wood"..drawer_type, def)
-	wrench.register_node("drawers:junglewood"..drawer_type, def)
-	wrench.register_node("drawers:pine_wood"..drawer_type, def)
+	wrench:register_node("drawers:wood"..drawer_type, def)
+	wrench:register_node("drawers:acacia_wood"..drawer_type, def)
+	wrench:register_node("drawers:aspen_wood"..drawer_type, def)
+	wrench:register_node("drawers:junglewood"..drawer_type, def)
+	wrench:register_node("drawers:pine_wood"..drawer_type, def)
 end

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -16,7 +16,7 @@ end
 
 register_node_on_off("mesecons_commandblock:commandblock", {
 	-- ignore after_place function: sets owner
-	owner = true,
+	owned = true,
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		commands = wrench.META_TYPE_STRING,

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -2,9 +2,9 @@
 -- Register wrench support for mesecons
 
 local function register_node_on_off(name, def)
-	wrench:register_node(name .. "_off", def)
+	wrench.register_node(name .. "_off", def)
 	def.drop = true
-	wrench:register_node(name .. "_on", def)
+	wrench.register_node(name .. "_on", def)
 end
 
 local desc_conf = function(pos, meta, node, player)
@@ -70,9 +70,9 @@ for b = 0, 1 do
 for c = 0, 1 do
 for d = 0, 1 do
 	local state = d .. c .. b .. a
-	wrench:register_node("mesecons_luacontroller:luacontroller" .. state, luacontroller_defs)
+	wrench.register_node("mesecons_luacontroller:luacontroller" .. state, luacontroller_defs)
 
-	wrench:register_node("mesecons_microcontroller:microcontroller" .. state, {
+	wrench.register_node("mesecons_microcontroller:microcontroller" .. state, {
 		drop = "mesecons_microcontroller:microcontroller0000",
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
@@ -92,4 +92,4 @@ end
 end
 
 luacontroller_defs.drop = nil
-wrench:register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)
+wrench.register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -1,8 +1,6 @@
 
 -- Register wrench support for mesecons
 
--- TODO: update neighboring mesecons:wire or nodes (via after_dig_node?)
-
 local function register_node_on_off(name, def)
 	wrench.register_node(name .. "_off", def)
 	def.drop = true

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -2,9 +2,9 @@
 -- Register wrench support for mesecons
 
 local function register_node_on_off(name, def)
-	wrench.register_node(name .. "_off", def)
+	wrench:register_node(name .. "_off", def)
 	def.drop = true
-	wrench.register_node(name .. "_on", def)
+	wrench:register_node(name .. "_on", def)
 end
 
 local desc_conf = function(pos, meta, node, player)
@@ -70,9 +70,9 @@ for b = 0, 1 do
 for c = 0, 1 do
 for d = 0, 1 do
 	local state = d .. c .. b .. a
-	wrench.register_node("mesecons_luacontroller:luacontroller" .. state, luacontroller_defs)
+	wrench:register_node("mesecons_luacontroller:luacontroller" .. state, luacontroller_defs)
 
-	wrench.register_node("mesecons_microcontroller:microcontroller" .. state, {
+	wrench:register_node("mesecons_microcontroller:microcontroller" .. state, {
 		drop = "mesecons_microcontroller:microcontroller0000",
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
@@ -92,4 +92,4 @@ end
 end
 
 luacontroller_defs.drop = nil
-wrench.register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)
+wrench:register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -2,9 +2,9 @@
 -- Register wrench support for mesecons
 
 local function register_node_on_off(name, def)
-	wrench.register_node(name .. "_off", def)
+	wrench.register_node(name.."_off", def)
 	def.drop = true
-	wrench.register_node(name .. "_on", def)
+	wrench.register_node(name.."_on", def)
 end
 
 local desc_conf = function(pos, meta, node, player)
@@ -49,7 +49,7 @@ register_node_on_off("mesecons_detector:object_detector", {
 
 -- Controllers
 
-local luacontroller_defs = {
+local luacontroller_def = {
 	drop = true,
 	metas = {
 		code = wrench.META_TYPE_STRING,
@@ -60,8 +60,23 @@ local luacontroller_defs = {
 		ignore_offevents = wrench.META_TYPE_STRING,
 	},
 	description = function(pos, meta, node, player)
-		local desc = minetest.registered_nodes[node.name].description
+		local desc = minetest.registered_nodes["mesecons_luacontroller:luacontroller0000"].description
 		return string.format("%s with code", desc)
+	end,
+}
+
+local microcontroller_def = {
+	drop = true,
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		code = wrench.META_TYPE_STRING,
+		afterid = wrench.META_TYPE_INT,
+		eeprom = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+		real_portstates = wrench.META_TYPE_INT,
+	},
+	description = function(pos, meta, node, player)
+		return meta:get_string("infotext")
 	end,
 }
 
@@ -69,27 +84,13 @@ for a = 0, 1 do
 for b = 0, 1 do
 for c = 0, 1 do
 for d = 0, 1 do
-	local state = d .. c .. b .. a
-	wrench.register_node("mesecons_luacontroller:luacontroller" .. state, luacontroller_defs)
-
-	wrench.register_node("mesecons_microcontroller:microcontroller" .. state, {
-		drop = "mesecons_microcontroller:microcontroller0000",
-		metas = {
-			infotext = wrench.META_TYPE_STRING,
-			code = wrench.META_TYPE_STRING,
-			afterid = wrench.META_TYPE_INT,
-			eeprom = wrench.META_TYPE_STRING,
-			formspec = wrench.META_TYPE_STRING,
-			real_portstates = wrench.META_TYPE_INT,
-		},
-	description = function(pos, meta, node, player)
-		return meta:get_string("infotext")
-	end,
-	})
+	local state = d..c..b..a
+	wrench.register_node("mesecons_luacontroller:luacontroller"..state, luacontroller_def)
+	wrench.register_node("mesecons_microcontroller:microcontroller"..state, microcontroller_def)
 end
 end
 end
 end
 
-luacontroller_defs.drop = nil
-wrench.register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)
+luacontroller_def.drop = nil
+wrench.register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_def)

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -1,0 +1,80 @@
+
+-- Register wrench support for mesecons
+
+-- TODO: update neighboring mesecons:wire or nodes (via after_dig_node?)
+
+local function register_node_on_off(name, def)
+	wrench.register_node(name .. "_off", def)
+	def.drop = true
+	wrench.register_node(name .. "_on", def)
+end
+
+-- Commandblock
+
+register_node_on_off("mesecons_commandblock:commandblock", {
+	-- ignore after_place function: sets owner
+	owner = true,
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		commands = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+		owner = wrench.META_TYPE_STRING,
+	},
+})
+
+-- Detectors
+
+register_node_on_off("mesecons_detector:node_detector", {
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		distance = wrench.META_TYPE_STRING,
+		digiline_channel = wrench.META_TYPE_STRING,
+		scanname = wrench.META_TYPE_STRING,
+	},
+})
+
+register_node_on_off("mesecons_detector:object_detector", {
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		digiline_channel = wrench.META_TYPE_STRING,
+		scanname = wrench.META_TYPE_STRING,
+	},
+})
+
+-- Controllers
+
+local luacontroller_defs = {
+	drop = true,
+	metas = {
+		code = wrench.META_TYPE_STRING,
+		lc_memory = wrench.META_TYPE_STRING,
+		luac_id = wrench.META_TYPE_INT,
+		formspec = wrench.META_TYPE_STRING,
+		real_portstates = wrench.META_TYPE_INT,
+	},
+}
+
+for a = 0, 1 do
+for b = 0, 1 do
+for c = 0, 1 do
+for d = 0, 1 do
+	local state = d .. c .. b .. a
+	wrench.register_node("mesecons_luacontroller:luacontroller" .. state, luacontroller_defs)
+
+	wrench.register_node("mesecons_microcontroller:microcontroller" .. state, {
+		drop = "mesecons_microcontroller:microcontroller0000",
+		metas = {
+			infotext = wrench.META_TYPE_STRING,
+			code = wrench.META_TYPE_STRING,
+			afterid = wrench.META_TYPE_INT,
+			eeprom = wrench.META_TYPE_STRING,
+			formspec = wrench.META_TYPE_STRING,
+			real_portstates = wrench.META_TYPE_INT,
+		},
+	})
+end
+end
+end
+end
+
+wrench.register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)

--- a/nodes/mesecons.lua
+++ b/nodes/mesecons.lua
@@ -7,6 +7,11 @@ local function register_node_on_off(name, def)
 	wrench.register_node(name .. "_on", def)
 end
 
+local desc_conf = function(pos, meta, node, player)
+        local desc = minetest.registered_nodes[node.name].description
+        return string.format("%s with configuration", desc)
+end
+
 -- Commandblock
 
 register_node_on_off("mesecons_commandblock:commandblock", {
@@ -18,6 +23,7 @@ register_node_on_off("mesecons_commandblock:commandblock", {
 		formspec = wrench.META_TYPE_STRING,
 		owner = wrench.META_TYPE_STRING,
 	},
+	description = desc_conf,
 })
 
 -- Detectors
@@ -29,6 +35,7 @@ register_node_on_off("mesecons_detector:node_detector", {
 		digiline_channel = wrench.META_TYPE_STRING,
 		scanname = wrench.META_TYPE_STRING,
 	},
+	description = desc_conf,
 })
 
 register_node_on_off("mesecons_detector:object_detector", {
@@ -37,6 +44,7 @@ register_node_on_off("mesecons_detector:object_detector", {
 		digiline_channel = wrench.META_TYPE_STRING,
 		scanname = wrench.META_TYPE_STRING,
 	},
+	description = desc_conf,
 })
 
 -- Controllers
@@ -49,7 +57,12 @@ local luacontroller_defs = {
 		luac_id = wrench.META_TYPE_INT,
 		formspec = wrench.META_TYPE_STRING,
 		real_portstates = wrench.META_TYPE_INT,
+		ignore_offevents = wrench.META_TYPE_STRING,
 	},
+	description = function(pos, meta, node, player)
+		local desc = minetest.registered_nodes[node.name].description
+		return string.format("%s with code", desc)
+	end,
 }
 
 for a = 0, 1 do
@@ -69,10 +82,14 @@ for d = 0, 1 do
 			formspec = wrench.META_TYPE_STRING,
 			real_portstates = wrench.META_TYPE_INT,
 		},
+	description = function(pos, meta, node, player)
+		return meta:get_string("infotext")
+	end,
 	})
 end
 end
 end
 end
 
+luacontroller_defs.drop = nil
 wrench.register_node("mesecons_luacontroller:luacontroller_burnt", luacontroller_defs)

--- a/nodes/mobs.lua
+++ b/nodes/mobs.lua
@@ -1,0 +1,13 @@
+
+-- Register wrench support for mobs_redo
+
+wrench.register_node("mobs:spawner", {
+	metas = {
+		command = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+	description = function(pos, meta, node, player)
+		return meta:get_string("infotext")
+	end,
+})

--- a/nodes/mobs.lua
+++ b/nodes/mobs.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for mobs_redo
 
-wrench.register_node("mobs:spawner", {
+wrench:register_node("mobs:spawner", {
 	metas = {
 		command = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/mobs.lua
+++ b/nodes/mobs.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for mobs_redo
 
-wrench:register_node("mobs:spawner", {
+wrench.register_node("mobs:spawner", {
 	metas = {
 		command = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/more_chests.lua
+++ b/nodes/more_chests.lua
@@ -16,7 +16,7 @@ local basic_chests = {
 }
 
 for _, chest in pairs(basic_chests) do
-	wrench.register_node(chest, {
+	wrench:register_node(chest, {
 		lists = {"main"},
 		metas = {
 			owner = wrench.META_TYPE_STRING,
@@ -28,7 +28,7 @@ end
 
 -- Shared Chest
 
-wrench.register_node("more_chests:shared", {
+wrench:register_node("more_chests:shared", {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,

--- a/nodes/more_chests.lua
+++ b/nodes/more_chests.lua
@@ -1,0 +1,40 @@
+
+-- Register wrench support for more_chests
+
+local basic_chests = {
+	"more_chests:cobble",
+	"more_chests:dropbox",
+	"more_chests:fridge",
+	"more_chests:big_fridge",
+	"more_chests:secret",
+	"more_chests:toolbox_acacia",
+	"more_chests:toolbox_aspen",
+	"more_chests:toolbox_jungle",
+	"more_chests:toolbox_pine",
+	"more_chests:toolbox_steel",
+	"more_chests:toolbox_wood",
+}
+
+for _,chest in pairs(basic_chests) do
+	wrench.register_node(chest, {
+		lists = {"main"},
+		metas = {
+			owner = wrench.META_TYPE_STRING,
+			infotext = wrench.META_TYPE_STRING,
+		},
+		owned = true,
+	})
+end
+
+-- Shared Chest
+
+wrench.register_node("more_chests:shared", {
+	lists = {"main"},
+	metas = {
+		owner = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+		shared = wrench.META_TYPE_STRING,
+	},
+	owned = true,
+})

--- a/nodes/more_chests.lua
+++ b/nodes/more_chests.lua
@@ -16,7 +16,7 @@ local basic_chests = {
 }
 
 for _, chest in pairs(basic_chests) do
-	wrench:register_node(chest, {
+	wrench.register_node(chest, {
 		lists = {"main"},
 		metas = {
 			owner = wrench.META_TYPE_STRING,
@@ -28,7 +28,7 @@ end
 
 -- Shared Chest
 
-wrench:register_node("more_chests:shared", {
+wrench.register_node("more_chests:shared", {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,

--- a/nodes/more_chests.lua
+++ b/nodes/more_chests.lua
@@ -15,7 +15,7 @@ local basic_chests = {
 	"more_chests:toolbox_wood",
 }
 
-for _,chest in pairs(basic_chests) do
+for _, chest in pairs(basic_chests) do
 	wrench.register_node(chest, {
 		lists = {"main"},
 		metas = {

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -31,8 +31,14 @@ local wielder_data = {
 }
 
 -- TODO: convert *_on to *_off nodes before pickpup?
+
 wrench.register_node("pipeworks:deployer_off", wielder_data)
 wrench.register_node("pipeworks:deployer_on", wielder_data)
 
 wrench.register_node("pipeworks:dispenser_off", wielder_data)
 wrench.register_node("pipeworks:dispenser_on", wielder_data)
+
+table.insert(wielder_data.lists, "pick");
+table.insert(wielder_data.lists, "ghost_pick");
+wrench.register_node("pipeworks:nodebreaker_off", wielder_data)
+wrench.register_node("pipeworks:nodebreaker_on", wielder_data)

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -13,7 +13,6 @@ end
 -- Autocrafter
 
 wrench.register_node("pipeworks:autocrafter", {
-	after_place = pipeworks.after_place,
 	lists = {"src", "dst", "recipe", "output"},
 	metas = {
 		enabled = wrench.META_TYPE_INT,
@@ -26,7 +25,6 @@ wrench.register_node("pipeworks:autocrafter", {
 })
 
 local wielder_data = {
-	after_place = pipeworks.after_place,
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
@@ -51,7 +49,6 @@ wrench.register_node("pipeworks:nodebreaker_on", wielder_data)
 -- Filters
 
 local filter_data = {
-	after_place = pipeworks.after_place,
 	lists = {"main"},
 	metas = {
 		slotseq_mode = wrench.META_TYPE_INT,
@@ -75,7 +72,6 @@ wrench.register_node("pipeworks:digiline_filter", filter_data)
 for i = 1, 10 do
 	wrench.register_node("pipeworks:mese_sand_tube_"..i, {
 		drop = true,
-		after_place = pipeworks.after_place,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 			formspec = wrench.META_TYPE_STRING,
@@ -85,7 +81,6 @@ for i = 1, 10 do
 	})
 	wrench.register_node("pipeworks:teleport_tube_"..i, {
 		drop = true,
-		after_place = pipeworks.after_place,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 			formspec = wrench.META_TYPE_STRING,
@@ -100,7 +95,6 @@ end
 
 local lua_tube_data = {
 	drop = true,
-	after_place = pipeworks.after_place,
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		code = wrench.META_TYPE_STRING,
@@ -117,7 +111,6 @@ local lua_tube_data = {
 
 local mese_tube_data = {
 	drop = true,
-	after_place = pipeworks.after_place,
 	lists = {},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -2,27 +2,21 @@
 -- Register wrench support for pipeworks
 
 wrench.register_node("pipeworks:autocrafter", {
-	lists = { "src", "dst", "recipe", "output" },
+	lists = {"src", "dst", "recipe", "output"},
 	metas = {
 		enabled = wrench.META_TYPE_INT,
 		channel = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
-        description = function(pos, meta, node, player)
+	description = function(pos, meta, node, player)
 		return meta:get_string("infotext")
 	end,
-	after_place = function(pos, player, stack)
-		local meta = minetest.get_meta(pos)
-		if meta and meta:get_int("enabled") == 1 then
-			local timer = minetest.get_node_timer(pos)
-			timer:start(1) -- craft_time = 1
-		end
-	end,
+	timer = true,
 })
 
 local wielder_data = {
-	lists = { "main" },
+	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,
@@ -38,7 +32,7 @@ wrench.register_node("pipeworks:deployer_on", wielder_data)
 wrench.register_node("pipeworks:dispenser_off", wielder_data)
 wrench.register_node("pipeworks:dispenser_on", wielder_data)
 
-table.insert(wielder_data.lists, "pick");
-table.insert(wielder_data.lists, "ghost_pick");
+table.insert(wielder_data.lists, "pick")
+table.insert(wielder_data.lists, "ghost_pick")
 wrench.register_node("pipeworks:nodebreaker_off", wielder_data)
 wrench.register_node("pipeworks:nodebreaker_on", wielder_data)

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -12,7 +12,7 @@ end
 
 -- Autocrafter
 
-wrench:register_node("pipeworks:autocrafter", {
+wrench.register_node("pipeworks:autocrafter", {
 	lists = {"src", "dst", "recipe", "output"},
 	metas = {
 		enabled = wrench.META_TYPE_INT,
@@ -33,16 +33,16 @@ local wielder_data = {
 	drop = true,
 }
 
-wrench:register_node("pipeworks:deployer_off", wielder_data)
-wrench:register_node("pipeworks:deployer_on", wielder_data)
+wrench.register_node("pipeworks:deployer_off", wielder_data)
+wrench.register_node("pipeworks:deployer_on", wielder_data)
 
-wrench:register_node("pipeworks:dispenser_off", wielder_data)
-wrench:register_node("pipeworks:dispenser_on", wielder_data)
+wrench.register_node("pipeworks:dispenser_off", wielder_data)
+wrench.register_node("pipeworks:dispenser_on", wielder_data)
 
 table.insert(wielder_data.lists, "pick")
 table.insert(wielder_data.lists, "ghost_pick")
-wrench:register_node("pipeworks:nodebreaker_off", wielder_data)
-wrench:register_node("pipeworks:nodebreaker_on", wielder_data)
+wrench.register_node("pipeworks:nodebreaker_off", wielder_data)
+wrench.register_node("pipeworks:nodebreaker_on", wielder_data)
 
 -- Filters
 
@@ -59,16 +59,16 @@ local filter_data = {
 	description = desc_ghost_items,
 }
 
-wrench:register_node("pipeworks:filter", filter_data)
-wrench:register_node("pipeworks:mese_filter", filter_data)
+wrench.register_node("pipeworks:filter", filter_data)
+wrench.register_node("pipeworks:mese_filter", filter_data)
 
 filter_data.metas["channel"] = wrench.META_TYPE_STRING
-wrench:register_node("pipeworks:digiline_filter", filter_data)
+wrench.register_node("pipeworks:digiline_filter", filter_data)
 
 -- Tubes (6d style): 'mese_sand_tube' and 'teleport_tube'
 
 for i = 1, 10 do
-	wrench:register_node("pipeworks:mese_sand_tube_"..i, {
+	wrench.register_node("pipeworks:mese_sand_tube_"..i, {
 		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
@@ -76,7 +76,7 @@ for i = 1, 10 do
 		},
 		description = desc_infotext,
 	})
-	wrench:register_node("pipeworks:teleport_tube_"..i, {
+	wrench.register_node("pipeworks:teleport_tube_"..i, {
 		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
@@ -120,7 +120,7 @@ for i = 1, 6 do
 	table.insert(mese_tube_data.lists, "line"..i)
 end
 
-wrench:register_node("pipeworks:lua_tube_burnt", lua_tube_data)
+wrench.register_node("pipeworks:lua_tube_burnt", lua_tube_data)
 
 for xm = 0, 1 do
 for xp = 0, 1 do
@@ -129,8 +129,8 @@ for yp = 0, 1 do
 for zm = 0, 1 do
 for zp = 0, 1 do
 	local tname = xm..xp..ym..yp..zm..zp
-	wrench:register_node("pipeworks:lua_tube"..tname, lua_tube_data)
-	wrench:register_node("pipeworks:mese_tube_"..tname, mese_tube_data)
+	wrench.register_node("pipeworks:lua_tube"..tname, lua_tube_data)
+	wrench.register_node("pipeworks:mese_tube_"..tname, mese_tube_data)
 end
 end
 end

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -31,7 +31,6 @@ local wielder_data = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
-	-- drop node in state 'off' like digging
 	drop = true,
 }
 

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -19,6 +19,7 @@ wrench.register_node("pipeworks:autocrafter", {
 		channel = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
+		splitstacks = wrench.META_TYPE_INT,
 	},
 	description = desc_infotext,
 	timer = true,
@@ -28,8 +29,6 @@ local wielder_data = {
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
-		infotext = wrench.META_TYPE_STRING,
-		formspec = wrench.META_TYPE_STRING,
 	},
 	drop = true,
 }
@@ -73,7 +72,6 @@ for i = 1, 10 do
 		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
-			formspec = wrench.META_TYPE_STRING,
 			dist = wrench.META_TYPE_INT,
 		},
 		description = desc_infotext,
@@ -112,7 +110,6 @@ local mese_tube_data = {
 	drop = true,
 	lists = {},
 	metas = {
-		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
 	description = desc_ghost_items,

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -22,9 +22,9 @@ local wielder_data = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
+	-- drop node in state 'off' like digging
+	drop = true,
 }
-
--- TODO: convert *_on to *_off nodes before pickpup?
 
 wrench.register_node("pipeworks:deployer_off", wielder_data)
 wrench.register_node("pipeworks:deployer_on", wielder_data)

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -71,7 +71,7 @@ wrench.register_node("pipeworks:digiline_filter", filter_data)
 
 for i = 1, 10 do
 	wrench.register_node("pipeworks:mese_sand_tube_"..i, {
-		drop = 1,
+		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 			formspec = wrench.META_TYPE_STRING,
@@ -80,7 +80,7 @@ for i = 1, 10 do
 		description = desc_infotext,
 	})
 	wrench.register_node("pipeworks:teleport_tube_"..i, {
-		drop = 1,
+		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 			formspec = wrench.META_TYPE_STRING,
@@ -94,7 +94,7 @@ end
 -- Tubes (old style): 'lua_tube' and 'mese_tube'
 
 local lua_tube_data = {
-	drop = 1,
+	drop = true,
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		code = wrench.META_TYPE_STRING,
@@ -110,7 +110,7 @@ local lua_tube_data = {
 }
 
 local mese_tube_data = {
-	drop = 1,
+	drop = true,
 	lists = {},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -13,6 +13,7 @@ end
 -- Autocrafter
 
 wrench.register_node("pipeworks:autocrafter", {
+	after_place = pipeworks.after_place,
 	lists = {"src", "dst", "recipe", "output"},
 	metas = {
 		enabled = wrench.META_TYPE_INT,
@@ -25,6 +26,7 @@ wrench.register_node("pipeworks:autocrafter", {
 })
 
 local wielder_data = {
+	after_place = pipeworks.after_place,
 	lists = {"main"},
 	metas = {
 		owner = wrench.META_TYPE_STRING,
@@ -49,6 +51,7 @@ wrench.register_node("pipeworks:nodebreaker_on", wielder_data)
 -- Filters
 
 local filter_data = {
+	after_place = pipeworks.after_place,
 	lists = {"main"},
 	metas = {
 		slotseq_mode = wrench.META_TYPE_INT,
@@ -72,6 +75,7 @@ wrench.register_node("pipeworks:digiline_filter", filter_data)
 for i = 1, 10 do
 	wrench.register_node("pipeworks:mese_sand_tube_"..i, {
 		drop = true,
+		after_place = pipeworks.after_place,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 			formspec = wrench.META_TYPE_STRING,
@@ -81,6 +85,7 @@ for i = 1, 10 do
 	})
 	wrench.register_node("pipeworks:teleport_tube_"..i, {
 		drop = true,
+		after_place = pipeworks.after_place,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 			formspec = wrench.META_TYPE_STRING,
@@ -95,6 +100,7 @@ end
 
 local lua_tube_data = {
 	drop = true,
+	after_place = pipeworks.after_place,
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 		code = wrench.META_TYPE_STRING,
@@ -111,6 +117,7 @@ local lua_tube_data = {
 
 local mese_tube_data = {
 	drop = true,
+	after_place = pipeworks.after_place,
 	lists = {},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -124,6 +131,8 @@ for i = 1, 6 do
 	table.insert(mese_tube_data.lists, "line"..i)
 end
 
+wrench.register_node("pipeworks:lua_tube_burnt", lua_tube_data)
+
 for xm = 0, 1 do
 for xp = 0, 1 do
 for ym = 0, 1 do
@@ -132,7 +141,6 @@ for zm = 0, 1 do
 for zp = 0, 1 do
 	local tname = xm..xp..ym..yp..zm..zp
 	wrench.register_node("pipeworks:lua_tube"..tname, lua_tube_data)
-	wrench.register_node("pipeworks:lua_tube"..tname.."_burnt", lua_tube_data)
 	wrench.register_node("pipeworks:mese_tube_"..tname, mese_tube_data)
 end
 end

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -12,7 +12,7 @@ end
 
 -- Autocrafter
 
-wrench.register_node("pipeworks:autocrafter", {
+wrench:register_node("pipeworks:autocrafter", {
 	lists = {"src", "dst", "recipe", "output"},
 	metas = {
 		enabled = wrench.META_TYPE_INT,
@@ -33,16 +33,16 @@ local wielder_data = {
 	drop = true,
 }
 
-wrench.register_node("pipeworks:deployer_off", wielder_data)
-wrench.register_node("pipeworks:deployer_on", wielder_data)
+wrench:register_node("pipeworks:deployer_off", wielder_data)
+wrench:register_node("pipeworks:deployer_on", wielder_data)
 
-wrench.register_node("pipeworks:dispenser_off", wielder_data)
-wrench.register_node("pipeworks:dispenser_on", wielder_data)
+wrench:register_node("pipeworks:dispenser_off", wielder_data)
+wrench:register_node("pipeworks:dispenser_on", wielder_data)
 
 table.insert(wielder_data.lists, "pick")
 table.insert(wielder_data.lists, "ghost_pick")
-wrench.register_node("pipeworks:nodebreaker_off", wielder_data)
-wrench.register_node("pipeworks:nodebreaker_on", wielder_data)
+wrench:register_node("pipeworks:nodebreaker_off", wielder_data)
+wrench:register_node("pipeworks:nodebreaker_on", wielder_data)
 
 -- Filters
 
@@ -59,16 +59,16 @@ local filter_data = {
 	description = desc_ghost_items,
 }
 
-wrench.register_node("pipeworks:filter", filter_data)
-wrench.register_node("pipeworks:mese_filter", filter_data)
+wrench:register_node("pipeworks:filter", filter_data)
+wrench:register_node("pipeworks:mese_filter", filter_data)
 
 filter_data.metas["channel"] = wrench.META_TYPE_STRING
-wrench.register_node("pipeworks:digiline_filter", filter_data)
+wrench:register_node("pipeworks:digiline_filter", filter_data)
 
 -- Tubes (6d style): 'mese_sand_tube' and 'teleport_tube'
 
 for i = 1, 10 do
-	wrench.register_node("pipeworks:mese_sand_tube_"..i, {
+	wrench:register_node("pipeworks:mese_sand_tube_"..i, {
 		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
@@ -76,7 +76,7 @@ for i = 1, 10 do
 		},
 		description = desc_infotext,
 	})
-	wrench.register_node("pipeworks:teleport_tube_"..i, {
+	wrench:register_node("pipeworks:teleport_tube_"..i, {
 		drop = true,
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
@@ -120,7 +120,7 @@ for i = 1, 6 do
 	table.insert(mese_tube_data.lists, "line"..i)
 end
 
-wrench.register_node("pipeworks:lua_tube_burnt", lua_tube_data)
+wrench:register_node("pipeworks:lua_tube_burnt", lua_tube_data)
 
 for xm = 0, 1 do
 for xp = 0, 1 do
@@ -129,8 +129,8 @@ for yp = 0, 1 do
 for zm = 0, 1 do
 for zp = 0, 1 do
 	local tname = xm..xp..ym..yp..zm..zp
-	wrench.register_node("pipeworks:lua_tube"..tname, lua_tube_data)
-	wrench.register_node("pipeworks:mese_tube_"..tname, mese_tube_data)
+	wrench:register_node("pipeworks:lua_tube"..tname, lua_tube_data)
+	wrench:register_node("pipeworks:mese_tube_"..tname, mese_tube_data)
 end
 end
 end

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -36,3 +36,38 @@ table.insert(wielder_data.lists, "pick")
 table.insert(wielder_data.lists, "ghost_pick")
 wrench.register_node("pipeworks:nodebreaker_off", wielder_data)
 wrench.register_node("pipeworks:nodebreaker_on", wielder_data)
+
+-- Filters
+
+local filter_data = {
+	lists = {"main"},
+	metas = {
+		slotseq_mode = wrench.META_TYPE_INT,
+		slotseq_index = wrench.META_TYPE_INT,
+		exmatch_mode = wrench.META_TYPE_INT,
+		owner = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+	description = function(pos, meta, node, player)
+		local desc = minetest.registered_nodes[node.name].description
+		return string.format("%s with configuration", desc)
+	end,
+}
+
+wrench.register_node("pipeworks:filter", filter_data)
+wrench.register_node("pipeworks:mese_filter", filter_data)
+
+filter_data.metas["channel"] = wrench.META_TYPE_STRING
+wrench.register_node("pipeworks:digiline_filter", filter_data)
+
+-- TODO: Tubes
+
+--[[
+local nodes = {
+	"pipeworks:teleport_tube",
+	"pipeworks:mese_tube_000010",
+	"pipeworks:lua_tube_000000",
+	"pipeworks:mese_sand_tube_2",
+}
+]]--

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -1,0 +1,38 @@
+
+-- Register wrench support for pipeworks
+
+wrench.register_node("pipeworks:autocrafter", {
+	lists = { "src", "dst", "recipe", "output" },
+	metas = {
+		enabled = wrench.META_TYPE_INT,
+		channel = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+        description = function(pos, meta, node, player)
+		return meta:get_string("infotext")
+	end,
+	after_place = function(pos, player, stack)
+		local meta = minetest.get_meta(pos)
+		if meta and meta:get_int("enabled") == 1 then
+			local timer = minetest.get_node_timer(pos)
+			timer:start(1) -- craft_time = 1
+		end
+	end,
+})
+
+local wielder_data = {
+	lists = { "main" },
+	metas = {
+		owner = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+}
+
+-- TODO: convert *_on to *_off nodes before pickpup?
+wrench.register_node("pipeworks:deployer_off", wielder_data)
+wrench.register_node("pipeworks:deployer_on", wielder_data)
+
+wrench.register_node("pipeworks:dispenser_off", wielder_data)
+wrench.register_node("pipeworks:dispenser_on", wielder_data)

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for pipeworks
 
-local desc_ghost_items = function(pos, meta, node, player)
+local desc_config = function(pos, meta, node, player)
 	local desc = minetest.registered_nodes[node.name].description
 	return string.format("%s with configuration", desc)
 end
@@ -56,7 +56,7 @@ local filter_data = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
-	description = desc_ghost_items,
+	description = desc_config,
 }
 
 wrench.register_node("pipeworks:filter", filter_data)
@@ -101,8 +101,8 @@ local lua_tube_data = {
 		real_portstates = wrench.META_TYPE_INT,
 	},
 	description = function(pos, meta, node, player)
-		local desc = minetest.registered_nodes[node.name].description
-		return string.format("%s with program", desc)
+		local desc = minetest.registered_nodes["pipeworks:lua_tube000000"].description
+		return string.format("%s with code", desc)
 	end,
 }
 
@@ -112,15 +112,13 @@ local mese_tube_data = {
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
 	},
-	description = desc_ghost_items,
+	description = desc_config,
 }
 
 for i = 1, 6 do
 	mese_tube_data.metas["l"..i.."s"] = wrench.META_TYPE_INT
 	table.insert(mese_tube_data.lists, "line"..i)
 end
-
-wrench.register_node("pipeworks:lua_tube_burnt", lua_tube_data)
 
 for xm = 0, 1 do
 for xp = 0, 1 do
@@ -137,3 +135,6 @@ end
 end
 end
 end
+
+lua_tube_data.drop = nil
+wrench.register_node("pipeworks:lua_tube_burnt", lua_tube_data)

--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -1,6 +1,17 @@
 
 -- Register wrench support for pipeworks
 
+local desc_ghost_items = function(pos, meta, node, player)
+	local desc = minetest.registered_nodes[node.name].description
+	return string.format("%s with configuration", desc)
+end
+
+local desc_infotext = function(pos, meta, node, player)
+	return meta:get_string("infotext")
+end
+
+-- Autocrafter
+
 wrench.register_node("pipeworks:autocrafter", {
 	lists = {"src", "dst", "recipe", "output"},
 	metas = {
@@ -9,9 +20,7 @@ wrench.register_node("pipeworks:autocrafter", {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
-	description = function(pos, meta, node, player)
-		return meta:get_string("infotext")
-	end,
+	description = desc_infotext,
 	timer = true,
 })
 
@@ -49,10 +58,7 @@ local filter_data = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
-	description = function(pos, meta, node, player)
-		local desc = minetest.registered_nodes[node.name].description
-		return string.format("%s with configuration", desc)
-	end,
+	description = desc_ghost_items,
 }
 
 wrench.register_node("pipeworks:filter", filter_data)
@@ -61,13 +67,76 @@ wrench.register_node("pipeworks:mese_filter", filter_data)
 filter_data.metas["channel"] = wrench.META_TYPE_STRING
 wrench.register_node("pipeworks:digiline_filter", filter_data)
 
--- TODO: Tubes
+-- Tubes (6d style): 'mese_sand_tube' and 'teleport_tube'
 
---[[
-local nodes = {
-	"pipeworks:teleport_tube",
-	"pipeworks:mese_tube_000010",
-	"pipeworks:lua_tube_000000",
-	"pipeworks:mese_sand_tube_2",
+for i = 1, 10 do
+	wrench.register_node("pipeworks:mese_sand_tube_"..i, {
+		drop = 1,
+		metas = {
+			infotext = wrench.META_TYPE_STRING,
+			formspec = wrench.META_TYPE_STRING,
+			dist = wrench.META_TYPE_INT,
+		},
+		description = desc_infotext,
+	})
+	wrench.register_node("pipeworks:teleport_tube_"..i, {
+		drop = 1,
+		metas = {
+			infotext = wrench.META_TYPE_STRING,
+			formspec = wrench.META_TYPE_STRING,
+			channel = wrench.META_TYPE_STRING,
+			can_receive = wrench.META_TYPE_INT,
+		},
+		description = desc_infotext,
+	})
+end
+
+-- Tubes (old style): 'lua_tube' and 'mese_tube'
+
+local lua_tube_data = {
+	drop = 1,
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		code = wrench.META_TYPE_STRING,
+		ignore_offevents = wrench.META_TYPE_STRING,
+		lc_memory  = wrench.META_TYPE_STRING,
+		luac_id = wrench.META_TYPE_INT,
+		real_portstates = wrench.META_TYPE_INT,
+	},
+	description = function(pos, meta, node, player)
+		local desc = minetest.registered_nodes[node.name].description
+		return string.format("%s with program", desc)
+	end,
 }
-]]--
+
+local mese_tube_data = {
+	drop = 1,
+	lists = {},
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+	description = desc_ghost_items,
+}
+
+for i = 1, 6 do
+	mese_tube_data.metas["l"..i.."s"] = wrench.META_TYPE_INT
+	table.insert(mese_tube_data.lists, "line"..i)
+end
+
+for xm = 0, 1 do
+for xp = 0, 1 do
+for ym = 0, 1 do
+for yp = 0, 1 do
+for zm = 0, 1 do
+for zp = 0, 1 do
+	local tname = xm..xp..ym..yp..zm..zp
+	wrench.register_node("pipeworks:lua_tube"..tname, lua_tube_data)
+	wrench.register_node("pipeworks:lua_tube"..tname.."_burnt", lua_tube_data)
+	wrench.register_node("pipeworks:mese_tube_"..tname, mese_tube_data)
+end
+end
+end
+end
+end
+end

--- a/nodes/technic.lua
+++ b/nodes/technic.lua
@@ -91,3 +91,24 @@ for _, tier in pairs({"LV", "MV", "HV"}) do
 		})
 	end
 end
+
+-- other machines
+
+wrench.register_node("technic:injector", {
+	lists = { "main" },
+	metas = {
+		splitstacks = wrench.META_TYPE_INT,
+		mode = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+	after_place = function(pos, player, stack)
+		local meta = minetest.get_meta(pos)
+		local form = meta and meta:get_string("formspec")
+		-- disabled when formspec contains 'enable' button
+		if form and string.find(form, "button[4,1;4,1;enable;", 1, true) then
+			local timer = minetest.get_node_timer(pos)
+			timer:stop()
+		end
+	end,
+})

--- a/nodes/technic.lua
+++ b/nodes/technic.lua
@@ -17,8 +17,8 @@ local function register_machine_node(nodename, tier)
 	wrench.register_node(nodename, {lists = lists, metas = metas})
 end
 
--- base_machines table row format: name = { extra meta fields }
-local defaults = { tiers = {"LV", "MV", "HV"} }
+-- base_machines table row format: name = {extra meta fields}
+local defaults = {tiers = {"LV", "MV", "HV"}}
 local base_machines = {
 	electric_furnace = defaults,
 	grinder = defaults,
@@ -92,23 +92,15 @@ for _, tier in pairs({"LV", "MV", "HV"}) do
 	end
 end
 
--- other machines
+-- Other machines
 
 wrench.register_node("technic:injector", {
-	lists = { "main" },
+	lists = {"main"},
 	metas = {
 		splitstacks = wrench.META_TYPE_INT,
 		mode = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
-	after_place = function(pos, player, stack)
-		local meta = minetest.get_meta(pos)
-		local form = meta and meta:get_string("formspec")
-		-- disabled when formspec contains 'enable' button
-		if form and string.find(form, "button[4,1;4,1;enable;", 1, true) then
-			local timer = minetest.get_node_timer(pos)
-			timer:stop()
-		end
-	end,
+	timer = true,
 })

--- a/nodes/technic.lua
+++ b/nodes/technic.lua
@@ -17,8 +17,8 @@ local function register_machine_node(nodename, tier)
 	wrench.register_node(nodename, {lists = lists, metas = metas})
 end
 
--- base_machines table row format: name = {extra meta fields}
 local defaults = {tiers = {"LV", "MV", "HV"}}
+
 local base_machines = {
 	electric_furnace = defaults,
 	grinder = defaults,
@@ -30,7 +30,7 @@ local base_machines = {
 }
 
 for name, data in pairs(base_machines) do
-	for _,tier in ipairs(data.tiers) do
+	for _, tier in ipairs(data.tiers) do
 		local nodename = "technic:"..tier:lower().."_"..name
 		register_machine_node(nodename, tier)
 		if minetest.registered_nodes[nodename.."_active"] then
@@ -39,7 +39,6 @@ for name, data in pairs(base_machines) do
 	end
 end
 
----------------------------------------------------------------------
 -- Special nodes
 
 wrench.register_node("technic:coal_alloy_furnace", {

--- a/nodes/technic.lua
+++ b/nodes/technic.lua
@@ -15,7 +15,7 @@ local function register_machine_node(nodename, tier)
 		tube_time = tier ~= "LV" and wrench.META_TYPE_INT or nil,
 		src_time = wrench.META_TYPE_INT,
 	}
-	wrench:register_node(nodename, {lists = lists, metas = metas})
+	wrench.register_node(nodename, {lists = lists, metas = metas})
 end
 
 local defaults = {tiers = {"LV", "MV", "HV"}}
@@ -42,7 +42,7 @@ end
 
 -- Special nodes
 
-wrench:register_node("technic:coal_alloy_furnace", {
+wrench.register_node("technic:coal_alloy_furnace", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -53,7 +53,7 @@ wrench:register_node("technic:coal_alloy_furnace", {
 	},
 })
 
-wrench:register_node("technic:coal_alloy_furnace_active", {
+wrench.register_node("technic:coal_alloy_furnace_active", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -64,7 +64,7 @@ wrench:register_node("technic:coal_alloy_furnace_active", {
 	},
 })
 
-wrench:register_node("technic:tool_workshop", {
+wrench.register_node("technic:tool_workshop", {
 	lists = {"src", "upgrade1", "upgrade2"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -76,7 +76,7 @@ wrench:register_node("technic:tool_workshop", {
 
 for _, tier in pairs({"LV", "MV", "HV"}) do
 	for i = 0, 8 do
-		wrench:register_node("technic:"..tier:lower().."_battery_box"..i, {
+		wrench.register_node("technic:"..tier:lower().."_battery_box"..i, {
 			lists = tier ~= "LV" and machine_invlist_upgrades or machine_invlist,
 			metas = {
 				infotext = wrench.META_TYPE_STRING,
@@ -93,7 +93,7 @@ end
 
 -- Other machines
 
-wrench:register_node("technic:injector", {
+wrench.register_node("technic:injector", {
 	lists = {"main"},
 	metas = {
 		splitstacks = wrench.META_TYPE_INT,

--- a/nodes/technic.lua
+++ b/nodes/technic.lua
@@ -15,7 +15,7 @@ local function register_machine_node(nodename, tier)
 		tube_time = tier ~= "LV" and wrench.META_TYPE_INT or nil,
 		src_time = wrench.META_TYPE_INT,
 	}
-	wrench.register_node(nodename, {lists = lists, metas = metas})
+	wrench:register_node(nodename, {lists = lists, metas = metas})
 end
 
 local defaults = {tiers = {"LV", "MV", "HV"}}
@@ -42,7 +42,7 @@ end
 
 -- Special nodes
 
-wrench.register_node("technic:coal_alloy_furnace", {
+wrench:register_node("technic:coal_alloy_furnace", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -53,7 +53,7 @@ wrench.register_node("technic:coal_alloy_furnace", {
 	},
 })
 
-wrench.register_node("technic:coal_alloy_furnace_active", {
+wrench:register_node("technic:coal_alloy_furnace_active", {
 	lists = {"fuel", "src", "dst"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -64,7 +64,7 @@ wrench.register_node("technic:coal_alloy_furnace_active", {
 	},
 })
 
-wrench.register_node("technic:tool_workshop", {
+wrench:register_node("technic:tool_workshop", {
 	lists = {"src", "upgrade1", "upgrade2"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -76,7 +76,7 @@ wrench.register_node("technic:tool_workshop", {
 
 for _, tier in pairs({"LV", "MV", "HV"}) do
 	for i = 0, 8 do
-		wrench.register_node("technic:"..tier:lower().."_battery_box"..i, {
+		wrench:register_node("technic:"..tier:lower().."_battery_box"..i, {
 			lists = tier ~= "LV" and machine_invlist_upgrades or machine_invlist,
 			metas = {
 				infotext = wrench.META_TYPE_STRING,
@@ -93,7 +93,7 @@ end
 
 -- Other machines
 
-wrench.register_node("technic:injector", {
+wrench:register_node("technic:injector", {
 	lists = {"main"},
 	metas = {
 		splitstacks = wrench.META_TYPE_INT,

--- a/nodes/technic.lua
+++ b/nodes/technic.lua
@@ -8,7 +8,8 @@ local function register_machine_node(nodename, tier)
 	local lists = tier ~= "LV" and machine_invlist_upgrades or machine_invlist
 	local metas = {
 		infotext = wrench.META_TYPE_STRING,
-		formspec = wrench.META_TYPE_STRING,
+		formspec = tier ~= "LV" and wrench.META_TYPE_STRING or nil,
+		splitstacks = tier ~= "LV" and wrench.META_TYPE_INT or nil,
 		[tier.."_EU_demand"] = wrench.META_TYPE_INT,
 		[tier.."_EU_input"] = wrench.META_TYPE_INT,
 		tube_time = tier ~= "LV" and wrench.META_TYPE_INT or nil,
@@ -67,7 +68,6 @@ wrench.register_node("technic:tool_workshop", {
 	lists = {"src", "upgrade1", "upgrade2"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
-		formspec = wrench.META_TYPE_STRING,
 		MV_EU_demand = wrench.META_TYPE_INT,
 		MV_EU_input = wrench.META_TYPE_INT,
 		tube_time = wrench.META_TYPE_INT

--- a/nodes/technic_chests.lua
+++ b/nodes/technic_chests.lua
@@ -62,17 +62,17 @@ local chests_meta = {
 }
 
 for name, metas in pairs(chests_meta) do
-	wrench:register_node("technic:"..name.."_chest", {
+	wrench.register_node("technic:"..name.."_chest", {
 		lists = {"main"},
 		metas = metas,
 		description = get_chest_description,
 	})
-	wrench:register_node("technic:"..name.."_protected_chest", {
+	wrench.register_node("technic:"..name.."_protected_chest", {
 		lists = {"main"},
 		metas = metas,
 		description = get_chest_description,
 	})
-	wrench:register_node("technic:"..name.."_locked_chest", {
+	wrench.register_node("technic:"..name.."_locked_chest", {
 		lists = {"main"},
 		metas = with_owner_field(metas),
 		description = get_chest_description,
@@ -101,17 +101,17 @@ local chest_mark_colors = {
 }
 
 for i = 1, 15 do
-	wrench:register_node("technic:gold_chest"..chest_mark_colors[i], {
+	wrench.register_node("technic:gold_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = chests_meta.gold,
 		description = get_chest_description,
 	})
-	wrench:register_node("technic:gold_protected_chest"..chest_mark_colors[i], {
+	wrench.register_node("technic:gold_protected_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = chests_meta.gold,
 		description = get_chest_description,
 	})
-	wrench:register_node("technic:gold_locked_chest"..chest_mark_colors[i], {
+	wrench.register_node("technic:gold_locked_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = with_owner_field(chests_meta.gold),
 		description = get_chest_description,

--- a/nodes/technic_chests.lua
+++ b/nodes/technic_chests.lua
@@ -1,6 +1,9 @@
 
 -- Register wrench support for technic_chests
 
+local has_pipeworks = minetest.get_modpath("pipeworks")
+local splitstacks = has_pipeworks and wrench.META_TYPE_INT
+
 local function get_chest_description(pos, meta, node)
 	local desc = minetest.registered_nodes[node.name].description
 	local text = meta:get_string("infotext")
@@ -20,24 +23,28 @@ local chests_meta = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 		sort_mode = wrench.META_TYPE_INT,
+		splitstacks = splitstacks,
 	},
 	copper = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 		sort_mode = wrench.META_TYPE_INT,
 		autosort = wrench.META_TYPE_INT,
+		splitstacks = splitstacks,
 	},
 	silver = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 		sort_mode = wrench.META_TYPE_INT,
 		autosort = wrench.META_TYPE_INT,
+		splitstacks = splitstacks,
 	},
 	gold = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 		sort_mode = wrench.META_TYPE_INT,
 		autosort = wrench.META_TYPE_INT,
+		splitstacks = splitstacks,
 	},
 	mithril = {
 		infotext = wrench.META_TYPE_STRING,
@@ -50,6 +57,7 @@ local chests_meta = {
 		send_inject = wrench.META_TYPE_INT,
 		send_pull = wrench.META_TYPE_INT,
 		send_overflow = wrench.META_TYPE_INT,
+		splitstacks = splitstacks,
 	},
 }
 

--- a/nodes/technic_chests.lua
+++ b/nodes/technic_chests.lua
@@ -75,21 +75,21 @@ end
 -- Register extra nodes with color marking for gold chest
 
 local chest_mark_colors = {
-	'_black',
-	'_blue',
-	'_brown',
-	'_cyan',
-	'_dark_green',
-	'_dark_grey',
-	'_green',
-	'_grey',
-	'_magenta',
-	'_orange',
-	'_pink',
-	'_red',
-	'_violet',
-	'_white',
-	'_yellow',
+	"_black",
+	"_blue",
+	"_brown",
+	"_cyan",
+	"_dark_green",
+	"_dark_grey",
+	"_green",
+	"_grey",
+	"_magenta",
+	"_orange",
+	"_pink",
+	"_red",
+	"_violet",
+	"_white",
+	"_yellow",
 }
 
 for i = 1, 15 do

--- a/nodes/technic_chests.lua
+++ b/nodes/technic_chests.lua
@@ -62,17 +62,17 @@ local chests_meta = {
 }
 
 for name, metas in pairs(chests_meta) do
-	wrench.register_node("technic:"..name.."_chest", {
+	wrench:register_node("technic:"..name.."_chest", {
 		lists = {"main"},
 		metas = metas,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:"..name.."_protected_chest", {
+	wrench:register_node("technic:"..name.."_protected_chest", {
 		lists = {"main"},
 		metas = metas,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:"..name.."_locked_chest", {
+	wrench:register_node("technic:"..name.."_locked_chest", {
 		lists = {"main"},
 		metas = with_owner_field(metas),
 		description = get_chest_description,
@@ -101,17 +101,17 @@ local chest_mark_colors = {
 }
 
 for i = 1, 15 do
-	wrench.register_node("technic:gold_chest"..chest_mark_colors[i], {
+	wrench:register_node("technic:gold_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = chests_meta.gold,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:gold_protected_chest"..chest_mark_colors[i], {
+	wrench:register_node("technic:gold_protected_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = chests_meta.gold,
 		description = get_chest_description,
 	})
-	wrench.register_node("technic:gold_locked_chest"..chest_mark_colors[i], {
+	wrench:register_node("technic:gold_locked_chest"..chest_mark_colors[i], {
 		lists = {"main"},
 		metas = with_owner_field(chests_meta.gold),
 		description = get_chest_description,

--- a/nodes/technic_cnc.lua
+++ b/nodes/technic_cnc.lua
@@ -4,10 +4,10 @@
 local has_pipeworks = minetest.get_modpath("pipeworks")
 
 local function register_cnc(name, def)
-	wrench.register_node(name, def)
+	wrench:register_node(name, def)
 	if minetest.registered_nodes[name.."_active"] then
 		-- Only available if technic is active
-		wrench.register_node(name.."_active", def)
+		wrench:register_node(name.."_active", def)
 	end
 end
 

--- a/nodes/technic_cnc.lua
+++ b/nodes/technic_cnc.lua
@@ -1,6 +1,8 @@
 
 -- Register wrench support for Technic CNC
 
+local has_pipeworks = minetest.get_modpath("pipeworks")
+
 local function register_cnc(name, def)
 	wrench.register_node(name, def)
 	if minetest.registered_nodes[name.."_active"] then
@@ -35,6 +37,7 @@ if minetest.registered_nodes["technic:cnc_mk2"] then
 			size = wrench.META_TYPE_INT,
 			program = wrench.META_TYPE_STRING,
 			cnc_user = wrench.META_TYPE_STRING,
+			splitstacks = has_pipeworks and wrench.META_TYPE_INT,
 		},
 	})
 end

--- a/nodes/technic_cnc.lua
+++ b/nodes/technic_cnc.lua
@@ -4,10 +4,10 @@
 local has_pipeworks = minetest.get_modpath("pipeworks")
 
 local function register_cnc(name, def)
-	wrench:register_node(name, def)
+	wrench.register_node(name, def)
 	if minetest.registered_nodes[name.."_active"] then
 		-- Only available if technic is active
-		wrench:register_node(name.."_active", def)
+		wrench.register_node(name.."_active", def)
 	end
 end
 

--- a/nodes/vessels.lua
+++ b/nodes/vessels.lua
@@ -1,0 +1,10 @@
+
+-- Register wrench support for vessels
+
+wrench.register_node("vessels:shelf", {
+	lists = { "vessels" },
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+})

--- a/nodes/vessels.lua
+++ b/nodes/vessels.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for vessels
 
-wrench:register_node("vessels:shelf", {
+wrench.register_node("vessels:shelf", {
 	lists = { "vessels" },
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/vessels.lua
+++ b/nodes/vessels.lua
@@ -1,7 +1,7 @@
 
 -- Register wrench support for vessels
 
-wrench.register_node("vessels:shelf", {
+wrench:register_node("vessels:shelf", {
 	lists = { "vessels" },
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -1,0 +1,115 @@
+
+-- Register wrench support for xdecor
+
+xdecor:register_repairable("wrench:wrench")
+
+local nodes = {
+	"xdecor:cabinet",
+	"xdecor:cabinet_half",
+	"xdecor:empty_shelf",
+	"xdecor:multishelf",
+}
+
+for _, nodename in pairs(nodes) do
+	wrench.register_node(nodename, {
+		lists = {"main"},
+	})
+end
+
+-- cauldron
+
+nodes = {
+	"xdecor:cauldron_empty",
+	"xdecor:cauldron_idle",
+	"xdecor:cauldron_boiling",
+	"xdecor:cauldron_soup",
+}
+
+local function translated(player, text)
+	local player_name = player:get_player_name()
+	local lang_code =  minetest.get_player_information(player_name).lang_code
+	return minetest.get_translated_string(lang_code, text)
+end
+
+for _, nodename in pairs(nodes) do
+	wrench.register_node(nodename, {
+		metas = {
+			infotext = wrench.META_TYPE_STRING,
+		},
+		description = function(pos, meta, node, player)
+			local str = translated(player, minetest.registered_nodes[node.name].infotext)
+			local i = string.find(str, "-")
+			return (i and i > 0) and string.sub(str, 1, i - 1) or str
+		end,
+
+	})
+end
+
+-- enchantment_table
+
+wrench.register_node("xdecor:enchantment_table", {
+	lists = { "tool", "mese" },
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+		formspec = wrench.META_TYPE_STRING,
+	},
+})
+
+-- itemframe
+
+wrench.register_node("xdecor:itemframe", {
+	metas = {
+		owner = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+		item = wrench.META_TYPE_STRING,
+	},
+	owned = true,
+	after_place = function(pos, player, stack)
+                -- force item update
+		local timer = minetest.get_node_timer(pos)
+		timer:start(0)
+	end,
+	description = function(pos, meta, node, player)
+		local desc = minetest.registered_nodes[node.name].description
+		local item = meta:get_string("item")
+		if item and item ~= "" then
+			local d = ItemStack(item):get_short_description()
+			return string.format("%s with \"%s\"", desc, d or item)
+		else
+			return desc
+		end
+	end,
+})
+
+-- mailbox
+
+local mailbox_metas = {
+	owner = wrench.META_TYPE_STRING,
+	infotext = wrench.META_TYPE_STRING,
+	formspec = wrench.META_TYPE_STRING,
+}
+
+for i = 1, 7 do
+    mailbox_metas["giver" .. i] = wrench.META_TYPE_STRING
+    mailbox_metas["stack" .. i] = wrench.META_TYPE_STRING
+end
+
+wrench.register_node("xdecor:mailbox", {
+	lists = {"mailbox", "drop"},
+	metas = mailbox_metas,
+	owned = true,
+})
+
+-- workbench
+
+wrench.register_node("xdecor:workbench", {
+	lists = { "tool", "input", "hammer", "forms", "storage" },
+	metas = {
+		infotext = wrench.META_TYPE_STRING,
+	},
+	owned = true,
+	after_place = function(pos, player, stack)
+		local timer = minetest.get_node_timer(pos)
+		timer:start(3.0)
+	end,
+})

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -11,7 +11,7 @@ local nodes = {
 }
 
 for _, nodename in pairs(nodes) do
-	wrench.register_node(nodename, {
+	wrench:register_node(nodename, {
 		lists = {"main"},
 	})
 end
@@ -26,7 +26,7 @@ nodes = {
 }
 
 for _, nodename in pairs(nodes) do
-	wrench.register_node(nodename, {
+	wrench:register_node(nodename, {
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 		},
@@ -39,7 +39,7 @@ end
 
 -- Chessboard
 
-wrench.register_node("realchess:chessboard", {
+wrench:register_node("realchess:chessboard", {
 	lists = {"board"},
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
@@ -70,7 +70,7 @@ wrench.register_node("realchess:chessboard", {
 
 -- Enchantment Table
 
-wrench.register_node("xdecor:enchantment_table", {
+wrench:register_node("xdecor:enchantment_table", {
 	lists = {"tool", "mese"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -80,7 +80,7 @@ wrench.register_node("xdecor:enchantment_table", {
 
 -- Hive
 
-wrench.register_node("xdecor:hive", {
+wrench:register_node("xdecor:hive", {
 	timer = true,
 	lists = {"honey"},
 	metas = {
@@ -91,7 +91,7 @@ wrench.register_node("xdecor:hive", {
 
 -- Item Frame
 
-wrench.register_node("xdecor:itemframe", {
+wrench:register_node("xdecor:itemframe", {
 	metas = {
 		owner = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,
@@ -128,7 +128,7 @@ for i = 1, 7 do
 	mailbox_metas["stack"..i] = wrench.META_TYPE_STRING
 end
 
-wrench.register_node("xdecor:mailbox", {
+wrench:register_node("xdecor:mailbox", {
 	lists = {"mailbox", "drop"},
 	metas = mailbox_metas,
 	owned = true,
@@ -136,7 +136,7 @@ wrench.register_node("xdecor:mailbox", {
 
 -- Workbench
 
-wrench.register_node("xdecor:workbench", {
+wrench:register_node("xdecor:workbench", {
 	lists = {"tool", "input", "hammer", "forms", "storage"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -37,6 +37,37 @@ for _, nodename in pairs(nodes) do
 	})
 end
 
+-- Chessboard
+
+wrench.register_node("realchess:chessboard", {
+	lists = {"board"},
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+
+		playerBlack = wrench.META_TYPE_STRING,
+		playerWhite = wrench.META_TYPE_STRING,
+		lastMove = wrench.META_TYPE_STRING,
+
+		blackAttacked = wrench.META_TYPE_STRING,
+		whiteAttacked = wrench.META_TYPE_STRING,
+
+		lastMoveTime = wrench.META_TYPE_INT,
+		castlingBlackL = wrench.META_TYPE_INT,
+		castlingBlackR = wrench.META_TYPE_INT,
+		castlingWhiteL = wrench.META_TYPE_INT,
+		castlingWhiteR = wrench.META_TYPE_INT,
+
+		moves = wrench.META_TYPE_STRING,
+		eaten = wrench.META_TYPE_STRING,
+		mode = wrench.META_TYPE_STRING,
+	},
+	description = function(pos, meta, node, player)
+		local desc = minetest.registered_nodes[node.name].description
+		return string.format("%s '%s' vs '%s'", desc, meta:get_string("playerWhite"), meta:get_sting("playerBlack"))
+	end
+})
+
 -- Enchantment Table
 
 wrench.register_node("xdecor:enchantment_table", {

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -64,7 +64,7 @@ wrench:register_node("realchess:chessboard", {
 	},
 	description = function(pos, meta, node, player)
 		local desc = minetest.registered_nodes[node.name].description
-		return string.format("%s '%s' vs '%s'", desc, meta:get_string("playerWhite"), meta:get_sting("playerBlack"))
+		return string.format("%s '%s' vs. '%s'", desc, meta:get_string("playerWhite"), meta:get_string("playerBlack"))
 	end
 })
 

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -16,7 +16,7 @@ for _, nodename in pairs(nodes) do
 	})
 end
 
--- cauldron
+-- Cauldron
 
 nodes = {
 	"xdecor:cauldron_empty",
@@ -27,7 +27,7 @@ nodes = {
 
 local function translated(player, text)
 	local player_name = player:get_player_name()
-	local lang_code =  minetest.get_player_information(player_name).lang_code
+	local lang_code = minetest.get_player_information(player_name).lang_code
 	return minetest.get_translated_string(lang_code, text)
 end
 
@@ -45,17 +45,17 @@ for _, nodename in pairs(nodes) do
 	})
 end
 
--- enchantment_table
+-- Enchantment Table
 
 wrench.register_node("xdecor:enchantment_table", {
-	lists = { "tool", "mese" },
+	lists = {"tool", "mese"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 		formspec = wrench.META_TYPE_STRING,
 	},
 })
 
--- itemframe
+-- Item Frame
 
 wrench.register_node("xdecor:itemframe", {
 	metas = {
@@ -65,7 +65,7 @@ wrench.register_node("xdecor:itemframe", {
 	},
 	owned = true,
 	after_place = function(pos, player, stack)
-                -- force item update
+		-- Force item update
 		local timer = minetest.get_node_timer(pos)
 		timer:start(0)
 	end,
@@ -81,7 +81,7 @@ wrench.register_node("xdecor:itemframe", {
 	end,
 })
 
--- mailbox
+-- Mailbox
 
 local mailbox_metas = {
 	owner = wrench.META_TYPE_STRING,
@@ -90,8 +90,8 @@ local mailbox_metas = {
 }
 
 for i = 1, 7 do
-    mailbox_metas["giver" .. i] = wrench.META_TYPE_STRING
-    mailbox_metas["stack" .. i] = wrench.META_TYPE_STRING
+	mailbox_metas["giver" .. i] = wrench.META_TYPE_STRING
+	mailbox_metas["stack" .. i] = wrench.META_TYPE_STRING
 end
 
 wrench.register_node("xdecor:mailbox", {
@@ -100,16 +100,13 @@ wrench.register_node("xdecor:mailbox", {
 	owned = true,
 })
 
--- workbench
+-- Workbench
 
 wrench.register_node("xdecor:workbench", {
-	lists = { "tool", "input", "hammer", "forms", "storage" },
+	lists = {"tool", "input", "hammer", "forms", "storage" },
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 	},
 	owned = true,
-	after_place = function(pos, player, stack)
-		local timer = minetest.get_node_timer(pos)
-		timer:start(3.0)
-	end,
+	timer = true,
 })

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -34,7 +34,6 @@ for _, nodename in pairs(nodes) do
 			local desc = minetest.registered_nodes[node.name].description
 			return desc ~= "" and desc or minetest.registered_nodes[node.name].infotext
 		end,
-
 	})
 end
 
@@ -83,8 +82,8 @@ local mailbox_metas = {
 }
 
 for i = 1, 7 do
-	mailbox_metas["giver" .. i] = wrench.META_TYPE_STRING
-	mailbox_metas["stack" .. i] = wrench.META_TYPE_STRING
+	mailbox_metas["giver"..i] = wrench.META_TYPE_STRING
+	mailbox_metas["stack"..i] = wrench.META_TYPE_STRING
 end
 
 wrench.register_node("xdecor:mailbox", {
@@ -96,7 +95,7 @@ wrench.register_node("xdecor:mailbox", {
 -- Workbench
 
 wrench.register_node("xdecor:workbench", {
-	lists = {"tool", "input", "hammer", "forms", "storage" },
+	lists = {"tool", "input", "hammer", "forms", "storage"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
 	},

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -11,7 +11,7 @@ local nodes = {
 }
 
 for _, nodename in pairs(nodes) do
-	wrench:register_node(nodename, {
+	wrench.register_node(nodename, {
 		lists = {"main"},
 	})
 end
@@ -26,7 +26,7 @@ nodes = {
 }
 
 for _, nodename in pairs(nodes) do
-	wrench:register_node(nodename, {
+	wrench.register_node(nodename, {
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 		},
@@ -39,7 +39,7 @@ end
 
 -- Chessboard
 
-wrench:register_node("realchess:chessboard", {
+wrench.register_node("realchess:chessboard", {
 	lists = {"board"},
 	metas = {
 		formspec = wrench.META_TYPE_STRING,
@@ -70,7 +70,7 @@ wrench:register_node("realchess:chessboard", {
 
 -- Enchantment Table
 
-wrench:register_node("xdecor:enchantment_table", {
+wrench.register_node("xdecor:enchantment_table", {
 	lists = {"tool", "mese"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,
@@ -80,7 +80,7 @@ wrench:register_node("xdecor:enchantment_table", {
 
 -- Hive
 
-wrench:register_node("xdecor:hive", {
+wrench.register_node("xdecor:hive", {
 	timer = true,
 	lists = {"honey"},
 	metas = {
@@ -91,7 +91,7 @@ wrench:register_node("xdecor:hive", {
 
 -- Item Frame
 
-wrench:register_node("xdecor:itemframe", {
+wrench.register_node("xdecor:itemframe", {
 	metas = {
 		owner = wrench.META_TYPE_STRING,
 		infotext = wrench.META_TYPE_STRING,
@@ -128,7 +128,7 @@ for i = 1, 7 do
 	mailbox_metas["stack"..i] = wrench.META_TYPE_STRING
 end
 
-wrench:register_node("xdecor:mailbox", {
+wrench.register_node("xdecor:mailbox", {
 	lists = {"mailbox", "drop"},
 	metas = mailbox_metas,
 	owned = true,
@@ -136,7 +136,7 @@ wrench:register_node("xdecor:mailbox", {
 
 -- Workbench
 
-wrench:register_node("xdecor:workbench", {
+wrench.register_node("xdecor:workbench", {
 	lists = {"tool", "input", "hammer", "forms", "storage"},
 	metas = {
 		infotext = wrench.META_TYPE_STRING,

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -25,21 +25,14 @@ nodes = {
 	"xdecor:cauldron_soup",
 }
 
-local function translated(player, text)
-	local player_name = player:get_player_name()
-	local lang_code = minetest.get_player_information(player_name).lang_code
-	return minetest.get_translated_string(lang_code, text)
-end
-
 for _, nodename in pairs(nodes) do
 	wrench.register_node(nodename, {
 		metas = {
 			infotext = wrench.META_TYPE_STRING,
 		},
 		description = function(pos, meta, node, player)
-			local str = translated(player, minetest.registered_nodes[node.name].infotext)
-			local i = string.find(str, "-")
-			return (i and i > 0) and string.sub(str, 1, i - 1) or str
+			local desc = minetest.registered_nodes[node.name].description
+			return desc ~= "" and desc or minetest.registered_nodes[node.name].infotext
 		end,
 
 	})

--- a/nodes/xdecor.lua
+++ b/nodes/xdecor.lua
@@ -47,6 +47,17 @@ wrench.register_node("xdecor:enchantment_table", {
 	},
 })
 
+-- Hive
+
+wrench.register_node("xdecor:hive", {
+	timer = true,
+	lists = {"honey"},
+	metas = {
+		formspec = wrench.META_TYPE_STRING,
+		infotext = wrench.META_TYPE_STRING,
+	},
+})
+
 -- Item Frame
 
 wrench.register_node("xdecor:itemframe", {

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,1 @@
+wrench.enable_crafting (enable recipe for wrench) bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,1 +1,2 @@
-wrench.enable_crafting (enable recipe for wrench) bool true
+# Allows the wrench to be crafted if either the 'technic' or 'default' mod is installed.
+wrench.enable_crafting (Enable crafting recipe) bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,5 @@
 # Allows the wrench to be crafted if either the 'technic' or 'default' mod is installed.
 wrench.enable_crafting (Enable crafting recipe) bool true
+
+# Shows debug info in the console when the wrench is used with 'sneak' (very experimental)
+wrench.enable_debug (Shows debug info) bool false

--- a/spec/fixtures/bitchange.lua
+++ b/spec/fixtures/bitchange.lua
@@ -1,0 +1,39 @@
+
+-- Cleaned up copy/paste from https://github.com/SmallJoker/bitchange/blob/master/shop.lua
+-- Added forced registration to save setting modpaths and modname, wrench API should work
+--  without knowing anything about mod that is calling API to register nodes.
+
+minetest.register_node(":bitchange:shop", {
+	after_place_node = function(pos, placer)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("owner", placer:get_player_name())
+		meta:set_string("infotext", "Exchange shop (owned by "..meta:get_string("owner")..")")
+	end,
+	on_construct = function(pos)
+		local meta = minetest.get_meta(pos)
+		meta:set_string("infotext", "Exchange shop (constructing)")
+		meta:set_string("formspec", "test formspec")
+		meta:set_string("owner", "")
+		local inv = meta:get_inventory()
+		inv:set_size("stock", 5*4) -- needed stock for exchanges
+		inv:set_size("custm", 5*4) -- stock of the customers exchanges
+		inv:set_size("custm_ej", 4) -- ejected items if shop has no inventory room
+		inv:set_size("cust_ow", 2*2) -- owner wants
+		inv:set_size("cust_og", 2*2) -- owner gives
+		inv:set_size("cust_ej", 4) -- ejected items if player has no inventory room
+	end,
+})
+
+-- Modified from original: added `and wrench.plus` and changed `wrench:register_node` to `wrench.register_node`
+if minetest.get_modpath("wrench") and wrench and wrench.plus then
+	local STRING = wrench.META_TYPE_STRING
+	wrench.register_node("bitchange:shop", {
+		lists = {"stock", "custm", "custm_ej", "cust_ow", "cust_og", "cust_ej"},
+		metas = {
+			owner = STRING,
+			infotext = STRING,
+			title = STRING,
+		},
+		owned = true
+	})
+end

--- a/spec/fixtures/default.lua
+++ b/spec/fixtures/default.lua
@@ -1,0 +1,14 @@
+
+local function register_node(name, groups, additional_definition)
+	local definition = {
+		description = name.." description",
+		tiles = { "default_"..name },
+		groups = groups,
+	}
+	for k,v in pairs(additional_definition or {}) do definition[k] = v end
+	minetest.register_node(":default:"..name, definition)
+end
+
+-- Register some basic nodes
+register_node("stone", {cracky = 3, stone = 1}, {is_ground_content = true, drop = "default:cobble"})
+register_node("cobble", {cracky=3, stone = 2})

--- a/spec/fixtures/minetest.conf
+++ b/spec/fixtures/minetest.conf
@@ -1,0 +1,2 @@
+#wrench.enable_crafting = true
+#wrench.enable_crafting = false

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -1,0 +1,143 @@
+require("mineunit")
+
+-- Some Mineunit modules, should be good enough for wrench
+mineunit("core")
+mineunit("protection")
+mineunit("player")
+mineunit("server")
+
+-- Just for default:stone, could use other stuff like air or unknown nodes...
+fixture("default")
+
+-- Load wrench mod
+sourcefile("init")
+
+-- Load bitchange mod fixture for tests, depends on wrench
+fixture("bitchange")
+
+describe("Wrench", function()
+
+	-- Create world with 5 x 1 x 1 stone layer in case node placement requires support node below location.
+	world.set_default_node("air")
+	world.layout({
+		{{{x=0,y=0,z=0},{x=4,y=0,z=0}}, "default:stone"},
+	})
+
+	-- Execute on mods loaded callbacks to finish loading mods.
+	mineunit:mods_loaded()
+
+	local Sam = Player("Sam")
+	local SX = Player("SX")
+
+	function wrench_test_setup_and_teardown()
+		-- Basic setup and teardown for tests, setup/teardown can be stacked within describe block
+		setup(function()
+			-- reset and join players, Sam gets new wrench:wrench
+			Sam:do_reset()
+			SX:do_reset()
+			mineunit:execute_on_joinplayer(Sam)
+			mineunit:execute_on_joinplayer(SX)
+			Sam:get_inventory():set_stack("main", 1, ItemStack("wrench:wrench"))
+		end)
+		teardown(function()
+			-- after test set it done players will leave
+			mineunit:execute_on_leaveplayer(SX)
+			mineunit:execute_on_leaveplayer(Sam)
+		end)
+	end
+
+	describe("bitchange:shop", function()
+
+		wrench_test_setup_and_teardown()
+		setup(function()
+			-- Place bitchange:shop and insert some item stacks into inventories
+			world.place_node({x=0,y=1,z=0}, "bitchange:shop", Sam)
+			minetest.get_meta({x=0,y=1,z=0}):get_inventory():set_stack("stock", 2, "default:stone 42")
+			minetest.get_meta({x=0,y=1,z=0}):get_inventory():set_stack("cust_ow", 3, "default:sand 1")
+		end)
+
+		it("can be picked up", function()
+			-- Sam uses wrench holding sneak targeting node at pos from directly above it
+			Sam:do_use_from_above({x=0,y=1,z=0}, {sneak=true})
+
+			-- Check that bitchange:shop node is gone from world
+			assert.nodename("air", {x=0,y=1,z=0})
+
+			-- Check that Sam got correct item, next test does extended validation for stack
+			assert.has_item(Sam, "main", 2, "bitchange:shop 1")
+		end)
+
+		it("correctly placed after picked up", function()
+			-- SX gets and places shop itemstack picked up by Sam
+			SX:get_inventory():set_stack("main", 1, Sam:get_inventory():get_stack("main", 2))
+			SX:do_place_from_above({x=2,y=1,z=0})
+
+			-- Check that correct node was placed
+			assert.nodename("bitchange:shop", {x=2,y=1,z=0})
+
+			-- Get metadata for validation
+			local meta = minetest.get_meta({x=2,y=1,z=0})
+
+			-- Validate metadata fields of placed node
+			local expected_fields = {
+				owner = "Sam",
+				infotext = "Exchange shop (owned by Sam)",
+				formspec = "test formspec",
+			}
+			assert.same(expected_fields, meta:to_table().fields)
+
+			-- Validate inventory of placed node
+			local inv = meta:get_inventory()
+			assert.equals(5*4, inv:get_size("stock"))
+			assert.equals(5*4, inv:get_size("custm"))
+			assert.equals(4, inv:get_size("custm_ej"))
+			assert.equals(2*2, inv:get_size("cust_ow"))
+			assert.equals(2*2, inv:get_size("cust_og"))
+			assert.equals(4, inv:get_size("cust_ej"))
+
+			-- Check that inventory contains expected items and other slots are empty
+			assert.same(ItemStack(), inv:get_stack("stock", 1))
+			assert.same(ItemStack("default:stone 42"), inv:get_stack("stock", 2))
+			assert.same(ItemStack(), inv:get_stack("cust_ow", 2))
+			assert.same(ItemStack("default:sand 1"), inv:get_stack("cust_ow", 3))
+		end)
+
+	end)
+
+	describe("default:cobble", function()
+
+		wrench_test_setup_and_teardown()
+		setup(function()
+			world.place_node({x=1,y=1,z=0}, "default:cobble", Sam)
+		end)
+
+		it("cannot be picked up", function()
+			-- Sam uses wrench holding sneak targeting node at pos from directly above it
+			Sam:do_use_from_above({x=1,y=1,z=0}, {sneak=true})
+
+			-- Check that default:cobble is still in world
+			assert.nodename("default:cobble", {x=1,y=1,z=0})
+
+			-- Check that Sam did not receive new item, second inventory slot is empty
+			assert.has_item(Sam, "main", 2, ItemStack())
+		end)
+
+	end)
+
+	describe("no-op tool use", function()
+
+		wrench_test_setup_and_teardown()
+
+		it("works pointing nothing", function()
+			-- Sam uses wrench holding sneak targeting nothing
+			Sam:set_pos({x=9999,y=9999,z=9999})
+			Sam:do_use({sneak=true})
+
+			-- Check that Sam still have wrench and did not receive new item
+			assert.has_item(Sam, "main", 1, "wrench:wrench 1")
+			assert.has_item(Sam, "main", 2, ItemStack())
+		end)
+
+	end)
+
+end)

--- a/spec/mineunit.conf
+++ b/spec/mineunit.conf
@@ -1,0 +1,5 @@
+time_step = 100
+verbose = 3
+exclude = {
+	"integration_test",
+}

--- a/tool.lua
+++ b/tool.lua
@@ -13,7 +13,7 @@ minetest.register_tool("wrench:wrench", {
 		if not pos or minetest.is_protected(pos, name) then
 			return
 		end
-		local picked_up, err_msg = wrench.pickup_node(pos, player)
+		local picked_up, err_msg = wrench:pickup_node(pos, player)
 		if not picked_up then
 			if err_msg then
 				minetest.chat_send_player(name, err_msg)

--- a/tool.lua
+++ b/tool.lua
@@ -30,9 +30,18 @@ if minetest.settings:get_bool("wrench.enable_crafting", true) then
 		minetest.register_craft({
 			output = "wrench:wrench",
 			recipe = {
-				{"technic:carbon_steel_ingot", "", "technic:carbon_steel_ingot"},
-				{"", "technic:carbon_steel_ingot", ""},
-				{"", "technic:carbon_steel_ingot", ""}
+				{"technic:stainless_steel_ingot", "", "technic:stainless_steel_ingot"},
+				{"", "technic:stainless_steel_ingot", ""},
+				{"", "technic:stainless_steel_ingot", ""}
+			}
+		})
+	elseif minetest.get_modpath("default") then
+		minetest.register_craft({
+			output = "wrench:wrench",
+			recipe = {
+				{"default:steel_ingot", "", "default:steel_ingot"},
+				{"", "default:steel_ingot", ""},
+				{"", "default:steel_ingot", ""}
 			}
 		})
 	end

--- a/tool.lua
+++ b/tool.lua
@@ -13,7 +13,7 @@ minetest.register_tool("wrench:wrench", {
 		if not pos or minetest.is_protected(pos, name) then
 			return
 		end
-		local picked_up, err_msg = wrench:pickup_node(pos, player)
+		local picked_up, err_msg = wrench.pickup_node(pos, player)
 		if not picked_up then
 			if err_msg then
 				minetest.chat_send_player(name, err_msg)

--- a/tool.lua
+++ b/tool.lua
@@ -25,13 +25,15 @@ minetest.register_tool("wrench:wrench", {
 	end,
 })
 
-if minetest.get_modpath("technic") and technic.config:get_bool("enable_wrench_crafting") then
-	minetest.register_craft({
-		output = "wrench:wrench",
-		recipe = {
-			{"technic:carbon_steel_ingot", "", "technic:carbon_steel_ingot"},
-			{"", "technic:carbon_steel_ingot", ""},
-			{"", "technic:carbon_steel_ingot", ""}
-		}
-	})
+if minetest.settings:get_bool("wrench.enable_crafting", true) then
+	if minetest.get_modpath("technic") then
+		minetest.register_craft({
+			output = "wrench:wrench",
+			recipe = {
+				{"technic:carbon_steel_ingot", "", "technic:carbon_steel_ingot"},
+				{"", "technic:carbon_steel_ingot", ""},
+				{"", "technic:carbon_steel_ingot", ""}
+			}
+		})
+	end
 end


### PR DESCRIPTION
Basic tests also showing bit more proper fixture use mentioned at https://github.com/mt-mods/wrench/pull/2#issuecomment-986022043

API is used in fixture, that's not exactly correct use and API call should be in spec instead but I guess you'll get the idea.

* Wrench
	* bitchange:shop
		* can be picked up
		* correctly placed after picked up
	* default:cobble
		* cannot be picked up
	* no-op tool use
		* works pointing nothing

There's no coverage reporting or any comments added by bot if tests pass, failure comment is added with test logs if tests fail.

~~There's a lot of commits because this branch is currently based on [wrench_support_extend](https://github.com/mt-mods/wrench/tree/wrench_support_extend)
All stuff is really in this single commit: https://github.com/mt-mods/wrench/commit/33348039cb3dda0de6fe8aae438ecff126c810b0~~
Changed base branch to be wrench_support_extend, if merged this can however be merged directly into master after #2 is done. I do recommend that because #2 is huge mixed changes already, bit over sized PR already.