### PR TITLE
Ignore pipeworks node breaker `ghost_pick` inventory list

### DIFF
--- a/nodes/pipeworks.lua
+++ b/nodes/pipeworks.lua
@@ -39,7 +39,7 @@ wrench.register_node("pipeworks:dispenser_off", wielder_data)
 wrench.register_node("pipeworks:dispenser_on", wielder_data)
 
 table.insert(wielder_data.lists, "pick")
-table.insert(wielder_data.lists, "ghost_pick")
+wielder_data.lists_ignore = {"ghost_pick"}
 wrench.register_node("pipeworks:nodebreaker_off", wielder_data)
 wrench.register_node("pipeworks:nodebreaker_on", wielder_data)
 


### PR DESCRIPTION
Should fix #43, but I haven't tested it.