### PR TITLE
Update `bones` support

### DIFF
--- a/nodes/bones.lua
+++ b/nodes/bones.lua
@@ -5,6 +5,10 @@ local S = wrench.translator
 
 if bones.redo then
 	local function can_pickup_bones(pos, player)
+		if bones.pickup_bones then
+			-- Bones can be picked up without a wrench, so don't pick them up.
+			return false
+		end
 		local meta = minetest.get_meta(pos)
 		if meta:get_string("infotext") == "" then
 			return false


### PR DESCRIPTION
The recent update to `bones` allows them to be picked up without a wrench, so this PR stops the wrench from picking them up. The registration is still needed so previously picked up bones can be placed without losing their items.